### PR TITLE
Support for multiple test cases in one YAML file

### DIFF
--- a/DECISION.md
+++ b/DECISION.md
@@ -13,3 +13,9 @@
 ### Solution 3: Use `pydantic`
 - **Description**: Define the schema using Pydantic models and parse the YAML into these models.
 - **Reasoning for Discarding**: While powerful, it adds a heavier dependency and might be more complex than needed for simple schema validation in this context.
+
+## Support for multiple test cases in one YAML file (2025-05-23 09:00)
+
+### Solution 1: Root `test_cases` array with common `project`/`signals` (Chosen)
+- **Description**: Introduce a `test_cases` field at the root, which is an array of objects, each containing a `name` and its own `test_steps`. Common `project` and `signals` definitions are shared.
+- **Reasoning**: It allows sharing the project and signal definitions across multiple test cases within the same file, reducing redundancy while keeping the structure clean.

--- a/DISCARDED.md
+++ b/DISCARDED.md
@@ -19,3 +19,13 @@
 ### Solution 2: Manual SVG Generation (2025-05-22 10:15)
 - **Description**: Write a custom script to generate SVG directly from YAML.
 - **Reason for Discarding**: High complexity and redundant given PlantUML's existing capabilities for timing diagrams.
+
+## Support for multiple test cases in one YAML file (2025-05-23 09:05)
+
+### Solution 2: Array of full test objects
+- **Description**: Define the entire YAML as an array of objects, each with its own `project`, `signals`, and `test_steps`.
+- **Reason for Discarding**: Redundant as `project` and `signals` would be duplicated for most test cases in the same file.
+
+### Solution 3: Separate YAML files
+- **Description**: Keep only one test case per YAML file and use multiple files.
+- **Reason for Discarding**: Does not meet the requirement of having multiple test cases in a single file, which is useful for organizing related tests.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,7 @@
 # Roadmap
 
 ## Finished
+- [x] Support for multiple test cases in one YAML file (2025-05-23)
 - [x] Implement YAML validator against the schema (2025-05-22)
 - [x] Create YAML data for "micropython-example-tt-devkit" (2025-05-22)
 - [x] Implement Python script to generate PlantUML timing diagram from YAML (2025-05-22)
@@ -10,7 +11,6 @@
 ## Planned
 - [ ] Add support for asynchronous signals (Planned)
 - [ ] Integrate with GHDL/Verilator for automated verification (Planned)
-- [ ] Support for multiple test cases in one YAML file (Planned)
 - [ ] Integration with a simulator to verify test steps (Planned)
 - [ ] Improve documentation with examples (Planned)
 

--- a/src/data/micropython_example.yaml
+++ b/src/data/micropython_example.yaml
@@ -16,69 +16,85 @@ signals:
     type: "output"
     width: 8
 
-test_steps:
-  - name: "Reset"
-    cycles: 1
-    values:
-      ENA: 1
-      RST_N: 0
-      UI_IN: 0
-      UIO: 0
+test_cases:
+  - name: "Full Protocol"
+    test_steps:
+      - name: "Reset"
+        cycles: 1
+        values:
+          ENA: 1
+          RST_N: 0
+          UI_IN: 0
+          UIO: 0
 
-  - name: "Cycle 0 (IDLE)"
-    cycles: 1
-    values:
-      ENA: 1
-      RST_N: 1
-      UI_IN: 0
-      UIO: 0
+      - name: "Cycle 0 (IDLE)"
+        cycles: 1
+        values:
+          ENA: 1
+          RST_N: 1
+          UI_IN: 0
+          UIO: 0
 
-  - name: "Cycle 1 (Load Scale A & Config)"
-    cycles: 1
-    values:
-      UI_IN: 127
-      UIO: 0
+      - name: "Cycle 1 (Load Scale A & Config)"
+        cycles: 1
+        values:
+          UI_IN: 127
+          UIO: 0
 
-  - name: "Cycle 2 (Load Scale B & Format B)"
-    cycles: 1
-    values:
-      UI_IN: 127
-      UIO: 0
+      - name: "Cycle 2 (Load Scale B & Format B)"
+        cycles: 1
+        values:
+          UI_IN: 127
+          UIO: 0
 
-  - name: "Cycles 3-34 (Stream 32 elements)"
-    cycles: 32
-    values:
-      UI_IN: 0x38
-      UIO: 0x38
+      - name: "Cycles 3-34 (Stream 32 elements)"
+        cycles: 32
+        values:
+          UI_IN: 0x38
+          UIO: 0x38
 
-  - name: "Cycle 35 (Pipeline Flush)"
-    cycles: 1
-    values:
-      UI_IN: 0
-      UIO: 0
+      - name: "Cycle 35 (Pipeline Flush)"
+        cycles: 1
+        values:
+          UI_IN: 0
+          UIO: 0
 
-  - name: "Cycle 36 (Final Shared Scaling)"
-    cycles: 1
-    values:
-      UI_IN: 0
-      UIO: 0
+      - name: "Cycle 36 (Final Shared Scaling)"
+        cycles: 1
+        values:
+          UI_IN: 0
+          UIO: 0
 
-  - name: "Cycle 37 (Read Result Byte 3)"
-    cycles: 1
-    values:
-      UO_OUT: "Result[31:24]"
+      - name: "Cycle 37 (Read Result Byte 3)"
+        cycles: 1
+        values:
+          UO_OUT: "Result[31:24]"
 
-  - name: "Cycle 38 (Read Result Byte 2)"
-    cycles: 1
-    values:
-      UO_OUT: "Result[23:16]"
+      - name: "Cycle 38 (Read Result Byte 2)"
+        cycles: 1
+        values:
+          UO_OUT: "Result[23:16]"
 
-  - name: "Cycle 39 (Read Result Byte 1)"
-    cycles: 1
-    values:
-      UO_OUT: "Result[15:8]"
+      - name: "Cycle 39 (Read Result Byte 1)"
+        cycles: 1
+        values:
+          UO_OUT: "Result[15:8]"
 
-  - name: "Cycle 40 (Read Result Byte 0)"
-    cycles: 1
-    values:
-      UO_OUT: "Result[7:0]"
+      - name: "Cycle 40 (Read Result Byte 0)"
+        cycles: 1
+        values:
+          UO_OUT: "Result[7:0]"
+
+  - name: "Short Reset"
+    test_steps:
+      - name: "Reset"
+        cycles: 2
+        values:
+          ENA: 1
+          RST_N: 0
+          UI_IN: 0
+          UIO: 0
+      - name: "Idle"
+        cycles: 1
+        values:
+          RST_N: 1

--- a/src/schema/test_steps.yaml
+++ b/src/schema/test_steps.yaml
@@ -17,6 +17,19 @@ properties:
           minimum: 1
       required: [type, width]
   test_steps:
+    $ref: "#/definitions/test_steps"
+  test_cases:
+    type: array
+    items:
+      type: object
+      properties:
+        name:
+          type: string
+        test_steps:
+          $ref: "#/definitions/test_steps"
+      required: [name, test_steps]
+definitions:
+  test_steps:
     type: array
     items:
       type: object
@@ -33,4 +46,7 @@ properties:
               - type: integer
               - type: string
       required: [name, cycles, values]
-required: [project, signals, test_steps]
+required: [project, signals]
+oneOf:
+  - required: [test_steps]
+  - required: [test_cases]

--- a/src/scripts/generate_waveform.py
+++ b/src/scripts/generate_waveform.py
@@ -4,7 +4,7 @@ import os
 import requests
 from plantuml import PlantUML
 
-def generate_puml(data):
+def generate_puml(data, test_steps):
     puml = ["@startuml"]
 
     # Declarations
@@ -29,13 +29,12 @@ def generate_puml(data):
         if sig_name == 'CLK': continue
         puml.append(f"{sig_name} is 0")
 
-    steps = data.get('test_steps', [])
     current_time = 0
     cycle_count = 0
     # Increased max cycles to capture the whole protocol
     max_cycles = 100
 
-    for step in steps:
+    for step in test_steps:
         if cycle_count >= max_cycles:
             break
 
@@ -82,6 +81,20 @@ def render_png(puml_content, output_path):
     except Exception as e:
         print(f"Error rendering: {e}")
 
+def process_test_case(data, test_steps, base_name, case_name=None):
+    puml_content = generate_puml(data, test_steps)
+
+    suffix = f"_{case_name}" if case_name else ""
+    puml_path = os.path.join("src/images", f"{base_name}{suffix}.puml")
+    png_path = os.path.join("src/images", f"{base_name}{suffix}.png")
+
+    os.makedirs("src/images", exist_ok=True)
+    with open(puml_path, 'w') as f:
+        f.write(puml_content)
+    print(f"Generated PlantUML source: {puml_path}")
+
+    render_png(puml_content, png_path)
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Usage: python generate_waveform.py <input_yaml>")
@@ -91,15 +104,14 @@ if __name__ == "__main__":
     with open(input_yaml, 'r') as f:
         data = yaml.safe_load(f)
 
-    puml_content = generate_puml(data)
-
     base_name = os.path.splitext(os.path.basename(input_yaml))[0]
-    puml_path = os.path.join("src/images", f"{base_name}.puml")
-    png_path = os.path.join("src/images", f"{base_name}.png")
 
-    os.makedirs("src/images", exist_ok=True)
-    with open(puml_path, 'w') as f:
-        f.write(puml_content)
-    print(f"Generated PlantUML source: {puml_path}")
-
-    render_png(puml_content, png_path)
+    if 'test_cases' in data:
+        for case in data['test_cases']:
+            print(f"Processing test case: {case['name']}")
+            process_test_case(data, case['test_steps'], base_name, case['name'].replace(" ", "_"))
+    elif 'test_steps' in data:
+        process_test_case(data, data['test_steps'], base_name)
+    else:
+        print("Error: No test_steps or test_cases found in YAML")
+        sys.exit(1)

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -4,7 +4,7 @@ import subprocess
 import pytest
 import sys
 
-def test_generator(tmp_path):
+def test_generator_single(tmp_path):
     test_yaml = tmp_path / "test_case.yaml"
 
     data = {
@@ -24,6 +24,35 @@ def test_generator(tmp_path):
     with open("src/images/test_case.puml", "r") as f:
         content = f.read()
         assert "@startuml" in content
-        # Tool now uses integer 1 for binary signals
         assert "SIG is 1" in content
         assert "SIG is Step_1" in content
+
+def test_generator_multiple(tmp_path):
+    test_yaml = tmp_path / "multi_test.yaml"
+
+    data = {
+        "project": "test",
+        "signals": {"SIG": {"type": "input", "width": 1}},
+        "test_cases": [
+            {"name": "Case A", "test_steps": [{"name": "Step A", "cycles": 1, "values": {"SIG": 1}}]},
+            {"name": "Case B", "test_steps": [{"name": "Step B", "cycles": 1, "values": {"SIG": 0}}]}
+        ]
+    }
+
+    with open(test_yaml, "w") as f:
+        yaml.dump(data, f)
+
+    result = subprocess.run([sys.executable, "src/scripts/generate_waveform.py", str(test_yaml)], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert os.path.exists("src/images/multi_test_Case_A.puml")
+    assert os.path.exists("src/images/multi_test_Case_B.puml")
+
+    with open("src/images/multi_test_Case_A.puml", "r") as f:
+        content = f.read()
+        assert "SIG is 1" in content
+        assert "SIG is Step_A" in content
+
+    with open("src/images/multi_test_Case_B.puml", "r") as f:
+        content = f.read()
+        assert "SIG is 0" in content
+        assert "SIG is Step_B" in content

--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -4,8 +4,8 @@ import subprocess
 import pytest
 import sys
 
-def test_validator_valid(tmp_path):
-    test_yaml = tmp_path / "valid_case.yaml"
+def test_validator_valid_single(tmp_path):
+    test_yaml = tmp_path / "valid_single.yaml"
     data = {
         "project": "test_project",
         "signals": {
@@ -23,13 +23,36 @@ def test_validator_valid(tmp_path):
     assert result.returncode == 0
     assert "Validation successful" in result.stdout
 
-def test_validator_invalid(tmp_path):
-    test_yaml = tmp_path / "invalid_case.yaml"
-    # Missing required 'project' field
+def test_validator_valid_multiple(tmp_path):
+    test_yaml = tmp_path / "valid_multiple.yaml"
     data = {
+        "project": "test_project",
         "signals": {
-            "CLK": {"type": "clock", "width": 1}
+            "CLK": {"type": "clock", "width": 1},
+            "DATA": {"type": "input", "width": 8}
         },
+        "test_cases": [
+            {
+                "name": "Case 1",
+                "test_steps": [{"name": "Step 1", "cycles": 1, "values": {"DATA": 0xAA}}]
+            },
+            {
+                "name": "Case 2",
+                "test_steps": [{"name": "Step 2", "cycles": 1, "values": {"DATA": 0xBB}}]
+            }
+        ]
+    }
+    with open(test_yaml, "w") as f:
+        yaml.dump(data, f)
+
+    result = subprocess.run([sys.executable, "src/scripts/validate_yaml.py", str(test_yaml)], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "Validation successful" in result.stdout
+
+def test_validator_invalid_missing_fields(tmp_path):
+    test_yaml = tmp_path / "invalid_missing.yaml"
+    # Missing required 'project' and 'signals' field
+    data = {
         "test_steps": []
     }
     with open(test_yaml, "w") as f:
@@ -56,3 +79,19 @@ def test_validator_invalid_signal_type(tmp_path):
     assert result.returncode != 0
     assert "Validation failed" in result.stdout
     assert "'invalid_type' is not one of ['input', 'output', 'inout', 'clock']" in result.stdout
+
+def test_validator_invalid_no_steps_or_cases(tmp_path):
+    test_yaml = tmp_path / "invalid_no_steps.yaml"
+    data = {
+        "project": "test",
+        "signals": {
+            "CLK": {"type": "clock", "width": 1}
+        }
+    }
+    with open(test_yaml, "w") as f:
+        yaml.dump(data, f)
+
+    result = subprocess.run([sys.executable, "src/scripts/validate_yaml.py", str(test_yaml)], capture_output=True, text=True)
+    assert result.returncode != 0
+    assert "Validation failed" in result.stdout
+    assert "is not valid under any of the given schemas" in result.stdout


### PR DESCRIPTION
This change adds support for defining multiple test cases within a single YAML file. The schema has been updated to include a 'test_cases' array, while maintaining backward compatibility for 'test_steps' at the root. The 'generate_waveform.py' script now iterates over these cases and generates separate output files for each. Tests and documentation have also been updated to reflect these changes.

Fixes #5

---
*PR created automatically by Jules for task [2181076151810386025](https://jules.google.com/task/2181076151810386025) started by @chatelao*