### PR TITLE
Add support for multiple test cases in YAML

### DIFF
--- a/DECISION.md
+++ b/DECISION.md
@@ -13,3 +13,17 @@
 ### Solution 3: Use `pydantic`
 - **Description**: Define the schema using Pydantic models and parse the YAML into these models.
 - **Reasoning for Discarding**: While powerful, it adds a heavier dependency and might be more complex than needed for simple schema validation in this context.
+
+## Support for Multiple Test Cases (2025-05-22 14:00)
+
+### Solution 1: Nested `test_cases` array (Chosen)
+- **Description**: Introduce a `test_cases` key at the root, which is an array of objects. Each object contains a `name` and its own `test_steps` array.
+- **Reasoning**: This provides a clear, named structure for multiple sequences while allowing them to share the top-level `project` and `signals` definitions.
+
+### Solution 2: Dictionary-based `test_steps`
+- **Description**: Modify `test_steps` to optionally be a dictionary where keys are case names and values are the step arrays.
+- **Reasoning for Discarding**: It makes the schema for `test_steps` more complex (union type) and is less explicit than a dedicated `test_cases` field.
+
+### Solution 3: Multi-document YAML
+- **Description**: Use YAML's `---` separator to define multiple complete test documents within a single file.
+- **Reasoning for Discarding**: This would require duplicating `project` and `signals` definitions in every document or implementing a complex merging logic.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,7 @@
 # Roadmap
 
 ## Finished
+- [x] Support for multiple test cases in one YAML file (2025-05-22)
 - [x] Implement YAML validator against the schema (2025-05-22)
 - [x] Create YAML data for "micropython-example-tt-devkit" (2025-05-22)
 - [x] Implement Python script to generate PlantUML timing diagram from YAML (2025-05-22)
@@ -10,7 +11,6 @@
 ## Planned
 - [ ] Add support for asynchronous signals (Planned)
 - [ ] Integrate with GHDL/Verilator for automated verification (Planned)
-- [ ] Support for multiple test cases in one YAML file (Planned)
 - [ ] Integration with a simulator to verify test steps (Planned)
 - [ ] Improve documentation with examples (Planned)
 

--- a/src/schema/test_steps.yaml
+++ b/src/schema/test_steps.yaml
@@ -17,6 +17,19 @@ properties:
           minimum: 1
       required: [type, width]
   test_steps:
+    $ref: "#/definitions/test_steps"
+  test_cases:
+    type: array
+    items:
+      type: object
+      properties:
+        name:
+          type: string
+        test_steps:
+          $ref: "#/definitions/test_steps"
+      required: [name, test_steps]
+definitions:
+  test_steps:
     type: array
     items:
       type: object
@@ -33,4 +46,7 @@ properties:
               - type: integer
               - type: string
       required: [name, cycles, values]
-required: [project, signals, test_steps]
+required: [project, signals]
+anyOf:
+  - required: [test_steps]
+  - required: [test_cases]

--- a/src/scripts/generate_waveform.py
+++ b/src/scripts/generate_waveform.py
@@ -4,7 +4,7 @@ import os
 import requests
 from plantuml import PlantUML
 
-def generate_puml(data):
+def generate_puml(data, test_steps):
     puml = ["@startuml"]
 
     # Declarations
@@ -29,7 +29,7 @@ def generate_puml(data):
         if sig_name == 'CLK': continue
         puml.append(f"{sig_name} is 0")
 
-    steps = data.get('test_steps', [])
+    steps = test_steps
     current_time = 0
     cycle_count = 0
     # Increased max cycles to capture the whole protocol
@@ -82,6 +82,20 @@ def render_png(puml_content, output_path):
     except Exception as e:
         print(f"Error rendering: {e}")
 
+def process_test_case(data, test_steps, output_base, case_name=None):
+    puml_content = generate_puml(data, test_steps)
+
+    suffix = f"_{case_name}" if case_name else ""
+    puml_path = os.path.join("src/images", f"{output_base}{suffix}.puml")
+    png_path = os.path.join("src/images", f"{output_base}{suffix}.png")
+
+    os.makedirs("src/images", exist_ok=True)
+    with open(puml_path, 'w') as f:
+        f.write(puml_content)
+    print(f"Generated PlantUML source: {puml_path}")
+
+    render_png(puml_content, png_path)
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Usage: python generate_waveform.py <input_yaml>")
@@ -91,15 +105,13 @@ if __name__ == "__main__":
     with open(input_yaml, 'r') as f:
         data = yaml.safe_load(f)
 
-    puml_content = generate_puml(data)
-
     base_name = os.path.splitext(os.path.basename(input_yaml))[0]
-    puml_path = os.path.join("src/images", f"{base_name}.puml")
-    png_path = os.path.join("src/images", f"{base_name}.png")
 
-    os.makedirs("src/images", exist_ok=True)
-    with open(puml_path, 'w') as f:
-        f.write(puml_content)
-    print(f"Generated PlantUML source: {puml_path}")
-
-    render_png(puml_content, png_path)
+    if 'test_cases' in data:
+        for case in data['test_cases']:
+            process_test_case(data, case['test_steps'], base_name, case['name'])
+    elif 'test_steps' in data:
+        process_test_case(data, data['test_steps'], base_name)
+    else:
+        print("Error: No test_steps or test_cases found in YAML.")
+        sys.exit(1)

--- a/test/test_generator.py
+++ b/test/test_generator.py
@@ -27,3 +27,40 @@ def test_generator(tmp_path):
         # Tool now uses integer 1 for binary signals
         assert "SIG is 1" in content
         assert "SIG is Step_1" in content
+
+def test_generator_multiple_cases(tmp_path):
+    test_yaml = tmp_path / "multi_case.yaml"
+
+    data = {
+        "project": "multi_test",
+        "signals": {"SIG": {"type": "input", "width": 1}},
+        "test_cases": [
+            {
+                "name": "CaseA",
+                "test_steps": [{"name": "Step A", "cycles": 1, "values": {"SIG": 1}}]
+            },
+            {
+                "name": "CaseB",
+                "test_steps": [{"name": "Step B", "cycles": 1, "values": {"SIG": 0}}]
+            }
+        ]
+    }
+
+    with open(test_yaml, "w") as f:
+        yaml.dump(data, f)
+
+    result = subprocess.run([sys.executable, "src/scripts/generate_waveform.py", str(test_yaml)], capture_output=True, text=True)
+    assert result.returncode == 0
+
+    assert os.path.exists("src/images/multi_case_CaseA.puml")
+    assert os.path.exists("src/images/multi_case_CaseB.puml")
+
+    with open("src/images/multi_case_CaseA.puml", "r") as f:
+        content = f.read()
+        assert "SIG is Step_A" in content
+        assert "SIG is 1" in content
+
+    with open("src/images/multi_case_CaseB.puml", "r") as f:
+        content = f.read()
+        assert "SIG is Step_B" in content
+        assert "SIG is 0" in content


### PR DESCRIPTION
This change implements support for defining multiple named test cases in a single YAML file. It includes schema updates, generator script refactoring to handle multiple cases, and a new test to ensure correct functionality and backward compatibility.

Fixes #7

---
*PR created automatically by Jules for task [17687508605842616525](https://jules.google.com/task/17687508605842616525) started by @chatelao*