### PR TITLE
Add TTIHP26A assigned projects to ROADMAP.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,6 +8,51 @@
 - [x] Initial project structure created (2025-05-22)
 
 ## Planned
+  - [ ] Create simple testcase for each assigned tile from TTIHP26A shuttle
+    - [ ] Test-ID: [3546](https://app.tinytapeout.com/projects/3546), Repo: https://github.com/mlhktp/ttihp-wokwi
+    - [ ] Test-ID: [3541](https://app.tinytapeout.com/projects/3541), Repo: https://github.com/zeynepdemirdag/tiny-tapeout-submission
+    - [ ] Test-ID: [3564](https://app.tinytapeout.com/projects/3564), Repo: https://github.com/DeeJayTF/deejay-tinytapeout
+    - [ ] Test-ID: [3657](https://app.tinytapeout.com/projects/3657), Repo: https://github.com/madsamtoft/TinyTapeout2
+    - [ ] Test-ID: [3674](https://app.tinytapeout.com/projects/3674), Repo: https://github.com/jonbng/tinytapeout-binary-to-7segment
+    - [ ] Test-ID: [3723](https://app.tinytapeout.com/projects/3723), Repo: https://github.com/Ghunk09/ttworkshop_TEST
+    - [ ] Test-ID: [3625](https://app.tinytapeout.com/projects/3625), Repo: https://github.com/terrywtr/Tianrui-Wang
+    - [ ] Test-ID: [3778](https://app.tinytapeout.com/projects/3778), Repo: https://github.com/TechHU-GS/analog-trial
+    - [ ] Test-ID: [3577](https://app.tinytapeout.com/projects/3577), Repo: https://github.com/by-Tobd/tinytapeout
+    - [ ] Test-ID: [3608](https://app.tinytapeout.com/projects/3608), Repo: https://github.com/TobisMa/GDS
+    - [ ] Test-ID: [3679](https://app.tinytapeout.com/projects/3679), Repo: https://github.com/Maximillian-Udar/TT
+    - [ ] Test-ID: [3697](https://app.tinytapeout.com/projects/3697), Repo: https://github.com/Daddybot/GDS
+    - [ ] Test-ID: [3760](https://app.tinytapeout.com/projects/3760), Repo: https://github.com/brunny95/Genesis
+    - [ ] Test-ID: [3704](https://app.tinytapeout.com/projects/3704), Repo: https://github.com/edga/tt_hello_gds
+    - [ ] Test-ID: [3551](https://app.tinytapeout.com/projects/3551), Repo: https://github.com/sisarikaya/mytiny
+    - [ ] Test-ID: [3666](https://app.tinytapeout.com/projects/3666), Repo: https://github.com/jonathan-farah/Sensors_and_Security
+    - [ ] Test-ID: [3984](https://app.tinytapeout.com/projects/3984), Repo: https://github.com/gfcwfzkm/ttihp_opamp_bfh_gesep1_mht1_msm9
+    - [ ] Test-ID: [3685](https://app.tinytapeout.com/projects/3685), Repo: https://github.com/Paafu/Create-the-GDS
+    - [ ] Test-ID: [3512](https://app.tinytapeout.com/projects/3512), Repo: https://github.com/danielowa/vga-tt
+    - [ ] Test-ID: [3764](https://app.tinytapeout.com/projects/3764), Repo: https://github.com/BoredSemiRetiredEngineer/ttihp_submission_other_tile
+    - [ ] Test-ID: [3762](https://app.tinytapeout.com/projects/3762), Repo: https://github.com/HecmacGPD/TTIHP-Hall-Sensor
+    - [ ] Test-ID: [3665](https://app.tinytapeout.com/projects/3665), Repo: https://github.com/umn-geocommons/tt_um_teenyspu
+    - [ ] Test-ID: [3684](https://app.tinytapeout.com/projects/3684), Repo: https://github.com/gcgc321/Tiny-Tapeout-Carry-Look-Ahead-Adder
+    - [ ] Test-ID: [3720](https://app.tinytapeout.com/projects/3720), Repo: https://github.com/edwar1r/TinyTapeoutCopenhagenFeb2026
+    - [ ] Test-ID: [3647](https://app.tinytapeout.com/projects/3647), Repo: https://github.com/Essenceia/Systolic_Array_with_DFT_v2
+    - [ ] Test-ID: [3614](https://app.tinytapeout.com/projects/3614), Repo: https://github.com/nusli7/TT-Project
+    - [ ] Test-ID: [3711](https://app.tinytapeout.com/projects/3711), Repo: https://github.com/ds-anik/Tiny-Tapeout
+    - [ ] Test-ID: [3603](https://app.tinytapeout.com/projects/3603), Repo: https://github.com/XxFanny17xX/tinytapeoutFY
+    - [ ] Test-ID: [3737](https://app.tinytapeout.com/projects/3737), Repo: https://github.com/ChiranjitPatel/tt_ihp26a_ringosc_stdcell
+    - [ ] Test-ID: [3957](https://app.tinytapeout.com/projects/3957), Repo: https://github.com/michaelstambach/vogal
+    - [ ] Test-ID: [3638](https://app.tinytapeout.com/projects/3638), Repo: https://github.com/zouzias/ttihp-verilog-eth
+    - [ ] Test-ID: [3556](https://app.tinytapeout.com/projects/3556), Repo: https://github.com/Duwandervall/yturkeri_mytinytapeout
+    - [ ] Test-ID: [3523](https://app.tinytapeout.com/projects/3523), Repo: https://github.com/hoene/tt_um_hoene_firsttry
+    - [ ] Test-ID: [3587](https://app.tinytapeout.com/projects/3587), Repo: https://github.com/lriglooC/tiny-tapeout-first-design
+    - [ ] Test-ID: [3581](https://app.tinytapeout.com/projects/3581), Repo: https://github.com/vlad-penchev/tinytapeoutz
+    - [ ] Test-ID: [3970](https://app.tinytapeout.com/projects/3970), Repo: https://github.com/TscherterJunior/tt_um_TscherterJunior_top
+    - [ ] Test-ID: [3724](https://app.tinytapeout.com/projects/3724), Repo: https://github.com/shreeveni-x90/SREE
+    - [ ] Test-ID: [3538](https://app.tinytapeout.com/projects/3538), Repo: https://github.com/mohamedelsharkawy101/tinytapout_test
+    - [ ] Test-ID: [3759](https://app.tinytapeout.com/projects/3759), Repo: https://github.com/jalcim/ttihp-jalcim_ihp_analog_tester
+    - [ ] Test-ID: [3609](https://app.tinytapeout.com/projects/3609), Repo: https://github.com/tippfehlr/tinytapeout
+    - [ ] Test-ID: [3707](https://app.tinytapeout.com/projects/3707), Repo: https://github.com/skippersboat/tinytapeout_create_your_gds
+    - [ ] Test-ID: [3618](https://app.tinytapeout.com/projects/3618), Repo: https://github.com/BenediktKeppner/tt-verilog
+    - [ ] Test-ID: [3975](https://app.tinytapeout.com/projects/3975), Repo: https://github.com/znah/ihp-ca
+
 - [ ] Add support for asynchronous signals (Planned)
 - [ ] Integrate with GHDL/Verilator for automated verification (Planned)
 - [ ] Support for multiple test cases in one YAML file (Planned)


### PR DESCRIPTION
Updated ROADMAP.md to include all 43 assigned projects for the TTIHP26A shuttle. Each entry provides the Test-ID (project number) as a link to the project page and includes the corresponding repository URL, as requested. The root directory was cleaned of temporary scraping data and project-level decision files were handled according to the existing project structure.

Fixes #8

---
*PR created automatically by Jules for task [8559592537196867571](https://jules.google.com/task/8559592537196867571) started by @chatelao*