### PR TITLE
Add verification for Test-ID 3564 (2-bit adder)

### DIFF
--- a/DECISION.md
+++ b/DECISION.md
@@ -61,3 +61,17 @@
 ### Solution 1: One full period (4 cycles) (Chosen)
 - **Description**: Define four test steps, each 1 cycle long, to verify the sequence 1, 2, 3, 4.
 - **Reasoning**: This is the most efficient way to confirm the core functionality of the counter as described in the specifications.
+
+## 2-Bit Adder Verification Strategy (Test-ID 3564) (2025-05-23 12:00)
+
+### Solution 1: Full Truth Table (16 cycles) (Chosen)
+- **Description**: Define 16 test steps to cover all combinations of two 2-bit inputs.
+- **Reasoning**: Provides exhaustive verification of the combinational logic for the 2-bit adder.
+
+### Solution 2: Representative Cases (8 cycles)
+- **Description**: Test only a subset of inputs (e.g., all zeros, all ones, and mixed values).
+- **Reasoning for Discarding**: Does not guarantee full correctness of the circuit, though faster to define.
+
+### Solution 3: Randomized Input Testing
+- **Description**: Generate random pairs of 2-bit numbers and verify the sum.
+- **Reasoning for Discarding**: Difficult to implement in a static YAML-based test framework without a script to pre-calculate results.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,7 @@
 
 ## Finished
 - [x] Create simple testcase for Test-ID 3541 (2 Bit Adder) (2025-05-23)
+- [x] Create simple testcase for Test-ID 3564 (2-Bit Adder) (2025-05-23)
 - [x] Create simple testcase for Test-ID 3546 (1-4 Counter) (2025-05-23)
 - [x] Support for multiple test cases in one YAML file (2025-05-22)
 - [x] Implement YAML validator against the schema (2025-05-22)
@@ -14,7 +15,7 @@
   - [ ] Create simple testcase for each assigned tile from TTIHP26A shuttle
     - [x] Test-ID: [3546](https://app.tinytapeout.com/projects/3546), Repo: https://github.com/mlhktp/ttihp-wokwi (2025-05-23)
     - [x] Test-ID: [3541](https://app.tinytapeout.com/projects/3541), Repo: https://github.com/zeynepdemirdag/tiny-tapeout-submission (2025-05-23)
-    - [ ] Test-ID: [3564](https://app.tinytapeout.com/projects/3564), Repo: https://github.com/DeeJayTF/deejay-tinytapeout
+    - [x] Test-ID: [3564](https://app.tinytapeout.com/projects/3564), Repo: https://github.com/DeeJayTF/deejay-tinytapeout (2025-05-23)
     - [ ] Test-ID: [3657](https://app.tinytapeout.com/projects/3657), Repo: https://github.com/madsamtoft/TinyTapeout2
     - [ ] Test-ID: [3674](https://app.tinytapeout.com/projects/3674), Repo: https://github.com/jonbng/tinytapeout-binary-to-7segment
     - [ ] Test-ID: [3723](https://app.tinytapeout.com/projects/3723), Repo: https://github.com/Ghunk09/ttworkshop_TEST

--- a/specifications/tt3564.original.md
+++ b/specifications/tt3564.original.md
@@ -1,0 +1,44 @@
+<!---
+
+This file is used to generate your project datasheet. Please fill in the information below and delete any unused
+sections.
+
+You can also include images in this folder and reference them in the markdown. Each image must be less than
+512 kb in size, and the combined size of all images must be less than 1 MB.
+-->
+
+## How it works
+
+A half-adder and a full-adder are used to build a 2-bit adder with a carry out signal.
+
+Two 2-bit numbers will be added and produced result will be given as 2 Bits and a 1 Bit carry out signal.
+
+## How to test
+
+Set the inputs according to the following truth table and check if the outputs match the truth table:
+
+| input a and b | output result | output cout |
+| --- | --- | --- |
+| 00 00 | 00 | 0 |
+| 00 01 | 01 | 0 |
+| 00 10 | 10 | 0 |
+| 00 11 | 11 | 0 |
+| 01 00 | 01 | 0 |
+| 01 01 | 10 | 0 |
+| 01 10 | 11 | 0 |
+| 01 11 | 00 | 1 |
+| 10 00 | 10 | 0 |
+| 10 01 | 11 | 0 |
+| 10 10 | 00 | 1 |
+| 10 11 | 01 | 1 |
+| 11 00 | 11 | 0 |
+| 11 01 | 00 | 1 |
+| 11 10 | 01 | 1 |
+| 11 11 | 10 | 1 |
+
+
+## External hardware
+
+Switches or buttons for input signals
+
+LEDs for output signals

--- a/specifications/tt3564.original.yaml
+++ b/specifications/tt3564.original.yaml
@@ -1,0 +1,49 @@
+# Tiny Tapeout project information (Wokwi project)
+project:
+  wokwi_id:     455291642978471937       # Set this to the ID of your Wokwi project (the number from the project's URL)
+  title:        "2-Bit Adder"      # Project title
+  author:       "Daniel Hönlinger"      # Your name
+  discord:      ""      # Your discord username, for communication and automatically assigning you a Tapeout role (optional)
+  description:  "Adds 2 2-bit numbers and outputs a 2-bit result with a 1-bit carry out signal"      # One line description of what your project does
+  language:     "Wokwi" # other examples include SystemVerilog, Amaranth, VHDL, etc
+  clock_hz:     0       # Clock frequency in Hz (or 0 if not applicable)
+
+  # How many tiles your design occupies? A single tile is about 167x108 uM.
+  tiles: "1x1"          # Valid values: 1x1, 1x2, 2x2, 3x2, 4x2, 6x2 or 8x2
+
+
+# The pinout of your project. Leave unused pins blank. DO NOT delete or add any pins.
+# This section is for the datasheet/website. Use descriptive names (e.g., RX, TX, MOSI, SCL, SEG_A, etc.).
+pinout:
+  # Inputs
+  ui[0]: "First Number - Bit 0"
+  ui[1]: "Second Number - Bit 0"
+  ui[2]: "First Number - Bit 1"
+  ui[3]: "Second Number - Bit 1"
+  ui[4]: ""
+  ui[5]: ""
+  ui[6]: ""
+  ui[7]: ""
+
+  # Outputs
+  uo[0]: "Result - Bit 0"
+  uo[1]: "Result - Bit 1"
+  uo[2]: "Carry Out"
+  uo[3]: ""
+  uo[4]: ""
+  uo[5]: ""
+  uo[6]: ""
+  uo[7]: ""
+
+  # Bidirectional pins
+  uio[0]: ""
+  uio[1]: ""
+  uio[2]: ""
+  uio[3]: ""
+  uio[4]: ""
+  uio[5]: ""
+  uio[6]: ""
+  uio[7]: ""
+
+# Do not change!
+yaml_version: 6

--- a/specifications/tt3564.yaml.md
+++ b/specifications/tt3564.yaml.md
@@ -1,0 +1,26 @@
+# Specification for Test-ID 3564 (2-Bit Adder)
+
+## Project Information
+
+- **Title**: 2-Bit Adder
+- **Author**: Daniel Hönlinger
+- **Description**: Adds 2 2-bit numbers and outputs a 2-bit result with a 1-bit carry out signal
+- **Language**: Wokwi
+
+## Pinout
+
+### Inputs
+- `ui[0]`: First Number - Bit 0
+- `ui[1]`: Second Number - Bit 0
+- `ui[2]`: First Number - Bit 1
+- `ui[3]`: Second Number - Bit 1
+
+### Outputs
+- `uo[0]`: Result - Bit 0
+- `uo[1]`: Result - Bit 1
+- `uo[2]`: Carry Out
+
+## Description
+
+A half-adder and a full-adder are used to build a 2-bit adder with a carry out signal.
+Two 2-bit numbers will be added and produced result will be given as 2 Bits and a 1 Bit carry out signal.

--- a/src/data/tt3564_2bit_adder.yaml
+++ b/src/data/tt3564_2bit_adder.yaml
@@ -1,0 +1,64 @@
+project: "tt3564-2bit-adder"
+signals:
+  A:
+    type: "input"
+    width: 2
+  B:
+    type: "input"
+    width: 2
+  Result:
+    type: "output"
+    width: 2
+  Cout:
+    type: "output"
+    width: 1
+
+test_steps:
+  - name: "0+0"
+    cycles: 1
+    values: {A: 0, B: 0, Result: 0, Cout: 0}
+  - name: "0+1"
+    cycles: 1
+    values: {A: 0, B: 1, Result: 1, Cout: 0}
+  - name: "0+2"
+    cycles: 1
+    values: {A: 0, B: 2, Result: 2, Cout: 0}
+  - name: "0+3"
+    cycles: 1
+    values: {A: 0, B: 3, Result: 3, Cout: 0}
+  - name: "1+0"
+    cycles: 1
+    values: {A: 1, B: 0, Result: 1, Cout: 0}
+  - name: "1+1"
+    cycles: 1
+    values: {A: 1, B: 1, Result: 2, Cout: 0}
+  - name: "1+2"
+    cycles: 1
+    values: {A: 1, B: 2, Result: 3, Cout: 0}
+  - name: "1+3"
+    cycles: 1
+    values: {A: 1, B: 3, Result: 0, Cout: 1}
+  - name: "2+0"
+    cycles: 1
+    values: {A: 2, B: 0, Result: 2, Cout: 0}
+  - name: "2+1"
+    cycles: 1
+    values: {A: 2, B: 1, Result: 3, Cout: 0}
+  - name: "2+2"
+    cycles: 1
+    values: {A: 2, B: 2, Result: 0, Cout: 1}
+  - name: "2+3"
+    cycles: 1
+    values: {A: 2, B: 3, Result: 1, Cout: 1}
+  - name: "3+0"
+    cycles: 1
+    values: {A: 3, B: 0, Result: 3, Cout: 0}
+  - name: "3+1"
+    cycles: 1
+    values: {A: 3, B: 1, Result: 0, Cout: 1}
+  - name: "3+2"
+    cycles: 1
+    values: {A: 3, B: 2, Result: 1, Cout: 1}
+  - name: "3+3"
+    cycles: 1
+    values: {A: 3, B: 3, Result: 2, Cout: 1}

--- a/src/scripts/generate_waveform.py
+++ b/src/scripts/generate_waveform.py
@@ -12,9 +12,10 @@ def generate_puml(data, test_steps):
     puml.append('concise "Phase" as SIG')
 
     signals = data.get('signals', {})
-    for sig_name in signals:
+    for sig_name, sig_info in signals.items():
         if sig_name == 'CLK': continue
-        if sig_name in ['UI_IN', 'UIO', 'UO_OUT']:
+        width = sig_info.get('width', 1)
+        if width > 1 or sig_name in ['UI_IN', 'UIO', 'UO_OUT']:
             puml.append(f'concise "{sig_name}" as {sig_name}')
         else:
             puml.append(f'binary "{sig_name}" as {sig_name}')

--- a/test/test_generator_width.py
+++ b/test/test_generator_width.py
@@ -1,0 +1,32 @@
+import os
+import yaml
+import subprocess
+import sys
+
+def test_generator_concise_width(tmp_path):
+    test_yaml = tmp_path / "concise_width.yaml"
+
+    data = {
+        "project": "test_concise",
+        "signals": {
+            "BUS": {"type": "input", "width": 4},
+            "BIT": {"type": "input", "width": 1}
+        },
+        "test_steps": [{"name": "Step 1", "cycles": 1, "values": {"BUS": 0xA, "BIT": 1}}]
+    }
+
+    with open(test_yaml, "w") as f:
+        yaml.dump(data, f)
+
+    result = subprocess.run([sys.executable, "src/scripts/generate_waveform.py", str(test_yaml)], capture_output=True, text=True)
+    assert result.returncode == 0
+
+    puml_file = "src/puml/concise_width.puml"
+    assert os.path.exists(puml_file)
+
+    with open(puml_file, "r") as f:
+        content = f.read()
+        assert 'concise "BUS" as BUS' in content
+        assert 'binary "BIT" as BIT' in content
+        assert "BUS is 10" in content
+        assert "BIT is 1" in content


### PR DESCRIPTION
I have implemented the next step in the roadmap by adding verification support for Test-ID 3564 (2-bit adder). 

Key changes:
1.  **Specifications**: Downloaded and archived original `info.md` and `info.yaml` for project 3564 into `specifications/`. Created a Markdown summary `tt3564.yaml.md`.
2.  **Tooling Improvement**: Updated `src/scripts/generate_waveform.py` to automatically use `concise` rendering for any signal with a `width` greater than 1. This improves the readability of waveforms for buses.
3.  **Test Data**: Created `src/data/tt3564_2bit_adder.yaml` with a full 16-step truth table to exhaustively verify the 2-bit adder logic.
4.  **Artifacts**: Validated the YAML and generated the corresponding PlantUML and PNG timing diagrams.
5.  **Documentation**: Updated `ROADMAP.md` to mark the task as finished and recorded the verification strategy decision in `DECISION.md`.
6.  **Testing**: Added `test/test_generator_width.py` to ensure the waveform generator correctly handles multi-bit signals. All tests passed.

Fixes #17

---
*PR created automatically by Jules for task [12763157562421782539](https://jules.google.com/task/12763157562421782539) started by @chatelao*