### PR TITLE
Add optional metadata source field to test case data

### DIFF
--- a/DECISION.md
+++ b/DECISION.md
@@ -1,5 +1,11 @@
 # Decisions
 
+## Implementation of Metadata and Source Field (2026-03-14 13:08)
+
+### Solution 1: Root and test_cases level metadata object (Chosen)
+- **Description**: Add a `metadata` object that can contain a `source` field at both the root level (global) and within each test case in `test_cases`.
+- **Reasoning**: Provides flexibility to specify a source for the entire file or for individual test cases if they come from different sources.
+
 ## Project Structure Reorganization (2025-05-23 09:00)
 
 ### Solution 1: Move images to /images and .puml to /src/puml (Chosen)

--- a/DISCARDED.md
+++ b/DISCARDED.md
@@ -1,5 +1,15 @@
 # Discarded Solutions
 
+## Implementation of Metadata and Source Field (2026-03-14 13:08)
+
+### Solution 2: Root level only metadata object
+- **Description**: Add a `metadata` object only at the root level of the YAML file.
+- **Reasoning for Discarding**: Limits the ability to specify different sources for multiple test cases within the same file.
+
+### Solution 3: Directly at root/case level without metadata object
+- **Description**: Add a `source` field directly at the root level or inside `test_cases` items without wrapping it in a `metadata` object.
+- **Reasoning for Discarding**: Less organized and makes it harder to add more metadata fields in the future without cluttering the top-level structure.
+
 ## 2-Bit Adder Verification Strategy (2025-05-23 11:00)
 
 ### Solution 2: Random Sampling (4 cycles)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,7 @@
 # Roadmap
 
 ## Finished
+- [x] Add optional source field to test case data (2026-03-14)
 - [x] Create simple testcase for Test-ID 3541 (2 Bit Adder) (2025-05-23)
 - [x] Create simple testcase for Test-ID 3546 (1-4 Counter) (2025-05-23)
 - [x] Support for multiple test cases in one YAML file (2025-05-22)

--- a/src/data/tt3541_2bit_adder.yaml
+++ b/src/data/tt3541_2bit_adder.yaml
@@ -1,4 +1,6 @@
 project: "tt3541-2bit-adder"
+metadata:
+  source: "https://github.com/zeynepdemirdag/tiny-tapeout-submission"
 signals:
   A:
     type: "input"

--- a/src/data/tt3546_counter.yaml
+++ b/src/data/tt3546_counter.yaml
@@ -1,4 +1,6 @@
 project: "tt3546-counter"
+metadata:
+  source: "https://github.com/mlhktp/ttihp-wokwi"
 signals:
   RST_N:
     type: "input"

--- a/src/schema/test_steps.yaml
+++ b/src/schema/test_steps.yaml
@@ -4,6 +4,11 @@ type: object
 properties:
   project:
     type: string
+  metadata:
+    type: object
+    properties:
+      source:
+        type: string
   signals:
     type: object
     additionalProperties:
@@ -25,6 +30,11 @@ properties:
       properties:
         name:
           type: string
+        metadata:
+          type: object
+          properties:
+            source:
+              type: string
         test_steps:
           $ref: "#/definitions/test_steps"
       required: [name, test_steps]

--- a/test/test_validator.py
+++ b/test/test_validator.py
@@ -56,3 +56,28 @@ def test_validator_invalid_signal_type(tmp_path):
     assert result.returncode != 0
     assert "Validation failed" in result.stdout
     assert "'invalid_type' is not one of ['input', 'output', 'inout', 'clock']" in result.stdout
+
+def test_validator_with_metadata(tmp_path):
+    test_yaml = tmp_path / "metadata_case.yaml"
+    data = {
+        "project": "test_project",
+        "metadata": {"source": "https://example.com/root"},
+        "signals": {
+            "CLK": {"type": "clock", "width": 1}
+        },
+        "test_cases": [
+            {
+                "name": "Case 1",
+                "metadata": {"source": "https://example.com/case1"},
+                "test_steps": [
+                    {"name": "Step 1", "cycles": 1, "values": {}}
+                ]
+            }
+        ]
+    }
+    with open(test_yaml, "w") as f:
+        yaml.dump(data, f)
+
+    result = subprocess.run([sys.executable, "src/scripts/validate_yaml.py", str(test_yaml)], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "Validation successful" in result.stdout


### PR DESCRIPTION
This change introduces an optional `metadata` object with a `source` field to the test case YAML schema. This allows users to document the origin of the test data (e.g., a GitHub repository URL). The field is available at both the root level (for global metadata) and within each test case in the `test_cases` array.

Existing data files for the counter and 2-bit adder have been updated with their corresponding source URLs. A new test has been added to the validator to ensure these new fields are correctly handled by the schema.

Fixes #18

---
*PR created automatically by Jules for task [75047596658039390](https://jules.google.com/task/75047596658039390) started by @chatelao*