### PR TITLE
Skip project 3390 (mini mosbius)

### DIFF
--- a/DECISION.md
+++ b/DECISION.md
@@ -1,5 +1,19 @@
 # Decisions
 
+## Handling of Project 3390 (mini mosbius) (2026-03-14 18:40)
+
+### Solution 1: Skip Project 3390 (Chosen)
+- **Description**: Skip the project because it is designated as "Analog" and belongs to the `ttsky25b` shuttle, which is outside the current digital verification scope for `ttihp26a`.
+- **Reasoning**: This adheres to the project policy of excluding analog designs and focusing on the primary `ttihp26a` shuttle for now.
+
+### Solution 2: Implement basic test case for Project 3390
+- **Description**: Create a minimal YAML test case for Project 3390 despite its analog nature.
+- **Reasoning for Discarding**: Our framework is optimized for digital logic, and analog projects are explicitly skipped according to project memory and guidelines.
+
+### Solution 3: Add to Planned section for ttsky25b
+- **Description**: Keep Project 3390 in the roadmap but move it to a future shuttle section.
+- **Reasoning for Discarding**: Unnecessary complexity as the current focus is entirely on completing the `ttihp26a` shuttle.
+
 ## Verification Strategy for 12 TTIHP26a Projects (2026-03-14 18:00)
 
 ### Solution 1: Manual exploration and YAML creation (Chosen)

--- a/DISCARDED.md
+++ b/DISCARDED.md
@@ -1,5 +1,15 @@
 # Discarded Solutions
 
+## Handling of Project 3390 (mini mosbius) (2026-03-14 18:40)
+
+### Solution 2: Implement basic test case for Project 3390
+- **Description**: Create a minimal YAML test case for Project 3390 despite its analog nature.
+- **Reasoning for Discarding**: Our framework is optimized for digital logic, and analog projects are explicitly skipped according to project memory and guidelines.
+
+### Solution 3: Add to Planned section for ttsky25b
+- **Description**: Keep Project 3390 in the roadmap but move it to a future shuttle section.
+- **Reasoning for Discarding**: Unnecessary complexity as the current focus is entirely on completing the `ttihp26a` shuttle.
+
 ## tinyTapeVerilog_out Verification Strategy (Test-ID 3526) (2026-03-14 23:00)
 
 ### Solution 2: Reset only

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,7 @@
 # Roadmap
 
 ## Finished
+- [x] Create simple testcase for Test-ID 3390 (mini mosbius) (Skipped - Analog / Not in shuttle ttihp26a) (2026-03-14)
 - [x] Create simple testcase for Test-ID 3756 (Photo Frame) (2026-03-14)
 - [x] Create simple testcase for Test-ID 3753 (FOMO) (2026-03-14)
 - [x] Create simple testcase for Test-ID 3750 (AdEx Neuron NCS) (Skipped - Analog) (2026-03-14)


### PR DESCRIPTION
Project 3390 was investigated and found to be an analog project in the ttsky25b shuttle. Since the current scope is limited to digital projects in the ttihp26a shuttle, it was decided to skip adding it to the testset. This decision, along with the discarded alternatives, has been documented in DECISION.md, DISCARDED.md, and ROADMAP.md.

Fixes #45

---
*PR created automatically by Jules for task [2852448720578830672](https://jules.google.com/task/2852448720578830672) started by @chatelao*