### PR TITLE
Reorganize Roadmap and Add Missing Shuttle Projects

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,183 @@
 # Roadmap
 
+## Planned
+  - [ ] Create simple testcase for each assigned tile from TTIHP26A shuttle
+    - [ ] Test-ID: [3502](https://app.tinytapeout.com/projects/3502), Repo: https://github.com/pranav0x0112/ttihp26a-Herald
+    - [ ] Test-ID: [3528](https://app.tinytapeout.com/projects/3528), Repo: https://github.com/chrismoos/tt-led-controller
+    - [ ] Test-ID: [3531](https://app.tinytapeout.com/projects/3531), Repo: https://github.com/Electronic-and-Computer-Engineering/TT_IHP26a_FH_uC
+    - [ ] Test-ID: [3533](https://app.tinytapeout.com/projects/3533), Repo: https://github.com/Fing2525/piggy_bag
+    - [ ] Test-ID: [3537](https://app.tinytapeout.com/projects/3537), Repo: https://github.com/svens0210/Roulette_Game
+    - [ ] Test-ID: [3539](https://app.tinytapeout.com/projects/3539), Repo: https://github.com/thravax/tt-test
+    - [ ] Test-ID: [3540](https://app.tinytapeout.com/projects/3540), Repo: https://github.com/PolykarposV/tt_workshop
+    - [ ] Test-ID: [3542](https://app.tinytapeout.com/projects/3542), Repo: https://github.com/ezelioli/tt-efcl-workshop
+    - [ ] Test-ID: [3543](https://app.tinytapeout.com/projects/3543), Repo: https://github.com/sotatek-dev/ttihp-SotaSoC
+    - [ ] Test-ID: [3545](https://app.tinytapeout.com/projects/3545), Repo: https://github.com/Byte-01100110/TT-Ape-out
+    - [ ] Test-ID: [3547](https://app.tinytapeout.com/projects/3547), Repo: https://github.com/raninninn/tiny-tapeout-working-repo
+    - [ ] Test-ID: [3548](https://app.tinytapeout.com/projects/3548), Repo: https://github.com/joh-1x/tiny-tapeout-workshop
+    - [ ] Test-ID: [3549](https://app.tinytapeout.com/projects/3549), Repo: https://github.com/tomolt/tomolt_tiny_tapeout_ic
+    - [ ] Test-ID: [3550](https://app.tinytapeout.com/projects/3550), Repo: https://github.com/elFuchso/tinytapeout-wokwi
+    - [ ] Test-ID: [3552](https://app.tinytapeout.com/projects/3552), Repo: https://github.com/alexey-serdyuk/tiny_tapeout_workshop
+    - [ ] Test-ID: [3553](https://app.tinytapeout.com/projects/3553), Repo: https://github.com/stsar/tiny_tapeout
+    - [ ] Test-ID: [3554](https://app.tinytapeout.com/projects/3554), Repo: https://github.com/MarvinBrth/7-Segment-Wokwi-Design
+    - [ ] Test-ID: [3555](https://app.tinytapeout.com/projects/3555), Repo: https://github.com/fschh/tt-experiment
+    - [ ] Test-ID: [3557](https://app.tinytapeout.com/projects/3557), Repo: https://github.com/tobiasgreiser/tiny_tapeout_workshop
+    - [ ] Test-ID: [3558](https://app.tinytapeout.com/projects/3558), Repo: https://github.com/PaxPlay/tiny-tapeout-design
+    - [ ] Test-ID: [3559](https://app.tinytapeout.com/projects/3559), Repo: https://github.com/Jannis-Uni/TinyTapeout
+    - [ ] Test-ID: [3560](https://app.tinytapeout.com/projects/3560), Repo: https://github.com/JohannesNekes/Tiny-Tapeout-RGB-PWM
+    - [ ] Test-ID: [3561](https://app.tinytapeout.com/projects/3561), Repo: https://github.com/yJulian/tiny-tapeout
+    - [ ] Test-ID: [3562](https://app.tinytapeout.com/projects/3562), Repo: https://github.com/Ancash/tt
+    - [ ] Test-ID: [3563](https://app.tinytapeout.com/projects/3563), Repo: https://github.com/yNiklas/tt-chip-design
+    - [ ] Test-ID: [3566](https://app.tinytapeout.com/projects/3566), Repo: https://github.com/DasKunstUngetuem/tt
+    - [ ] Test-ID: [3567](https://app.tinytapeout.com/projects/3567), Repo: https://github.com/trupus/tt
+    - [ ] Test-ID: [3568](https://app.tinytapeout.com/projects/3568), Repo: https://github.com/youju26/tinytapeout
+    - [ ] Test-ID: [3569](https://app.tinytapeout.com/projects/3569), Repo: https://github.com/agentzz1/GDS_tinytapeout
+    - [ ] Test-ID: [3570](https://app.tinytapeout.com/projects/3570), Repo: https://github.com/IsAreWhoKey/TTWorkshopThing
+    - [ ] Test-ID: [3572](https://app.tinytapeout.com/projects/3572), Repo: https://github.com/Aber-58/TinyTapeout-Aber
+    - [ ] Test-ID: [3573](https://app.tinytapeout.com/projects/3573), Repo: https://github.com/jackb7273-jpg/Tiny_Tapeout
+    - [ ] Test-ID: [3574](https://app.tinytapeout.com/projects/3574), Repo: https://github.com/Tuda05/TinyTapeout
+    - [ ] Test-ID: [3575](https://app.tinytapeout.com/projects/3575), Repo: https://github.com/pageeecs/FirstTapeout
+    - [ ] Test-ID: [3576](https://app.tinytapeout.com/projects/3576), Repo: https://github.com/MertErmann/tiny_tapeout_1
+    - [ ] Test-ID: [3578](https://app.tinytapeout.com/projects/3578), Repo: https://github.com/neb-o/tinytapeout_260207
+    - [ ] Test-ID: [3579](https://app.tinytapeout.com/projects/3579), Repo: https://github.com/dranoel06/tiny_tapeout_dranoel06
+    - [ ] Test-ID: [3580](https://app.tinytapeout.com/projects/3580), Repo: https://github.com/ManaOverflow/TinyTapeoutWorkshop
+    - [ ] Test-ID: [3582](https://app.tinytapeout.com/projects/3582), Repo: https://github.com/Shanmukha-ms/cim_tiny_tapeout
+    - [ ] Test-ID: [3584](https://app.tinytapeout.com/projects/3584), Repo: https://github.com/Tuan9304/gds
+    - [ ] Test-ID: [3585](https://app.tinytapeout.com/projects/3585), Repo: https://github.com/AriVishnu-01/Tiny-Tapeout
+    - [ ] Test-ID: [3586](https://app.tinytapeout.com/projects/3586), Repo: https://github.com/werrever/TinyTapeout_werrever
+    - [ ] Test-ID: [3588](https://app.tinytapeout.com/projects/3588), Repo: https://github.com/mar-3123/tiny_tapeout
+    - [ ] Test-ID: [3589](https://app.tinytapeout.com/projects/3589), Repo: https://github.com/83rk/83rkFlipFlop
+    - [ ] Test-ID: [3590](https://app.tinytapeout.com/projects/3590), Repo: https://github.com/jknotrowling/TinyTapeout
+    - [ ] Test-ID: [3591](https://app.tinytapeout.com/projects/3591), Repo: https://github.com/Nama222/Tiny-Tapeout
+    - [ ] Test-ID: [3592](https://app.tinytapeout.com/projects/3592), Repo: https://github.com/kenny3010/GDS1
+    - [ ] Test-ID: [3593](https://app.tinytapeout.com/projects/3593), Repo: https://github.com/Montagsfrei/TinyTapeoutWorkshop
+    - [ ] Test-ID: [3594](https://app.tinytapeout.com/projects/3594), Repo: https://github.com/darius1702/tt-asic
+    - [ ] Test-ID: [3595](https://app.tinytapeout.com/projects/3595), Repo: https://github.com/SinnMachen/nein
+    - [ ] Test-ID: [3596](https://app.tinytapeout.com/projects/3596), Repo: https://github.com/agentofail/TinyTapeout
+    - [ ] Test-ID: [3597](https://app.tinytapeout.com/projects/3597), Repo: https://github.com/Nampuk/tapatapatapa
+    - [ ] Test-ID: [3598](https://app.tinytapeout.com/projects/3598), Repo: https://github.com/Freddy-mllr/FreddysTapeout
+    - [ ] Test-ID: [3599](https://app.tinytapeout.com/projects/3599), Repo: https://github.com/mabo-elfotoh/my_tiny_tape_design
+    - [ ] Test-ID: [3600](https://app.tinytapeout.com/projects/3600), Repo: https://github.com/dabro02/Daniel-s-Wokwi-Design
+    - [ ] Test-ID: [3601](https://app.tinytapeout.com/projects/3601), Repo: https://github.com/RussLi-IDK/Create-the-GDS
+    - [ ] Test-ID: [3602](https://app.tinytapeout.com/projects/3602), Repo: https://github.com/PleinR02/test
+    - [ ] Test-ID: [3604](https://app.tinytapeout.com/projects/3604), Repo: https://github.com/ucmpb/TinyTapeout
+    - [ ] Test-ID: [3605](https://app.tinytapeout.com/projects/3605), Repo: https://github.com/ArthFink/TinyTapeout
+    - [ ] Test-ID: [3606](https://app.tinytapeout.com/projects/3606), Repo: https://github.com/alpblkba/tiny-tapeout-chip-design
+    - [ ] Test-ID: [3607](https://app.tinytapeout.com/projects/3607), Repo: https://github.com/RimaitosLab/TinyTapeoutWorkshop
+    - [ ] Test-ID: [3610](https://app.tinytapeout.com/projects/3610), Repo: https://github.com/LordTaek/GDS_Creator
+    - [ ] Test-ID: [3611](https://app.tinytapeout.com/projects/3611), Repo: https://github.com/Andreas-Noebel/Tiny-Tapeout
+    - [ ] Test-ID: [3612](https://app.tinytapeout.com/projects/3612), Repo: https://github.com/flo100500/tinytapeout
+    - [ ] Test-ID: [3613](https://app.tinytapeout.com/projects/3613), Repo: https://github.com/Engelbrecht-N/Wokiwi_template
+    - [ ] Test-ID: [3615](https://app.tinytapeout.com/projects/3615), Repo: https://github.com/Geronymos/tinytapeout
+    - [ ] Test-ID: [3616](https://app.tinytapeout.com/projects/3616), Repo: https://github.com/CT4111/test_WOKWI_Circute
+    - [ ] Test-ID: [3617](https://app.tinytapeout.com/projects/3617), Repo: https://github.com/plhrtr/TinyTapeOutTest
+    - [ ] Test-ID: [3619](https://app.tinytapeout.com/projects/3619), Repo: https://github.com/Shaip161/TinyTapeOut
+    - [ ] Test-ID: [3620](https://app.tinytapeout.com/projects/3620), Repo: https://github.com/can-lehmann/tt-fpga
+    - [ ] Test-ID: [3622](https://app.tinytapeout.com/projects/3622), Repo: https://github.com/DebuggingDisaster/wowki
+    - [ ] Test-ID: [3623](https://app.tinytapeout.com/projects/3623), Repo: https://github.com/pauld0503/paul_tiny_tapeout
+    - [ ] Test-ID: [3624](https://app.tinytapeout.com/projects/3624), Repo: https://github.com/makrs11/TinyTapeout-1
+    - [ ] Test-ID: [3626](https://app.tinytapeout.com/projects/3626), Repo: https://github.com/sam-m7/tinyTapeoutChip1
+    - [ ] Test-ID: [3627](https://app.tinytapeout.com/projects/3627), Repo: https://github.com/Estel64/Beccas_tinytapeout
+    - [ ] Test-ID: [3629](https://app.tinytapeout.com/projects/3629), Repo: https://github.com/kmosta19/TinyTapeoutProject
+    - [ ] Test-ID: [3630](https://app.tinytapeout.com/projects/3630), Repo: https://github.com/mattvenn/ihp26a-vga-test
+    - [ ] Test-ID: [3632](https://app.tinytapeout.com/projects/3632), Repo: https://github.com/matth-fischer/TT_VGA
+    - [ ] Test-ID: [3633](https://app.tinytapeout.com/projects/3633), Repo: https://github.com/phsauter/vga-playground-maze
+    - [ ] Test-ID: [3635](https://app.tinytapeout.com/projects/3635), Repo: https://github.com/apedersen00/tt6581
+    - [ ] Test-ID: [3640](https://app.tinytapeout.com/projects/3640), Repo: https://github.com/urish/tt-rings
+    - [ ] Test-ID: [3641](https://app.tinytapeout.com/projects/3641), Repo: https://github.com/brmurrell3/tt_um_brmurrell3_m31_accel
+    - [ ] Test-ID: [3642](https://app.tinytapeout.com/projects/3642), Repo: https://github.com/TheMightyDuckOfDoom/tinytapeout-bit-serial-collatz
+    - [ ] Test-ID: [3645](https://app.tinytapeout.com/projects/3645), Repo: https://github.com/gonsolo/borg_tinyqv
+    - [ ] Test-ID: [3648](https://app.tinytapeout.com/projects/3648), Repo: https://github.com/pgfarley/tophat
+    - [ ] Test-ID: [3650](https://app.tinytapeout.com/projects/3650), Repo: https://github.com/vppillai/tt-vga-submission
+    - [ ] Test-ID: [3651](https://app.tinytapeout.com/projects/3651), Repo: https://github.com/BoredSemiRetiredEngineer/ttihp_submission
+    - [ ] Test-ID: [3653](https://app.tinytapeout.com/projects/3653), Repo: https://github.com/rrrh/tiny_sid_chip
+    - [ ] Test-ID: [3654](https://app.tinytapeout.com/projects/3654), Repo: https://github.com/EzraWolf/TinyMOA-IHP26a
+    - [ ] Test-ID: [3656](https://app.tinytapeout.com/projects/3656), Repo: https://github.com/tjarker/ttihp-feb-2026
+    - [ ] Test-ID: [3659](https://app.tinytapeout.com/projects/3659), Repo: https://github.com/swenson/ttihp-quad-sieve
+    - [ ] Test-ID: [3661](https://app.tinytapeout.com/projects/3661), Repo: https://github.com/leonllrmc/tinytapeout_26a_llrsub1
+    - [ ] Test-ID: [3663](https://app.tinytapeout.com/projects/3663), Repo: https://github.com/EhsanKhodadad/ttihp-wokwi
+    - [ ] Test-ID: [3664](https://app.tinytapeout.com/projects/3664), Repo: https://github.com/pakesson/tt_glitcher
+    - [ ] Test-ID: [3667](https://app.tinytapeout.com/projects/3667), Repo: https://github.com/RipunjayS109/posit_mac
+    - [ ] Test-ID: [3668](https://app.tinytapeout.com/projects/3668), Repo: https://github.com/kessler-christopher/tt_chris_test
+    - [ ] Test-ID: [3669](https://app.tinytapeout.com/projects/3669), Repo: https://github.com/karlmose/tinytapeout_wokwi_test
+    - [ ] Test-ID: [3670](https://app.tinytapeout.com/projects/3670), Repo: https://github.com/AAmirinejad/TinyTapeoutWorkshop
+    - [ ] Test-ID: [3671](https://app.tinytapeout.com/projects/3671), Repo: https://github.com/Biboulder/TinyTapeout-wokwi-template
+    - [ ] Test-ID: [3675](https://app.tinytapeout.com/projects/3675), Repo: https://github.com/calonso88/dtu_tt_workshop
+    - [ ] Test-ID: [3676](https://app.tinytapeout.com/projects/3676), Repo: https://github.com/Mr-Seoul/TinyTapeOutGDS
+    - [ ] Test-ID: [3678](https://app.tinytapeout.com/projects/3678), Repo: https://github.com/MathiasKES/TinyTapeout2026-wokwi
+    - [ ] Test-ID: [3680](https://app.tinytapeout.com/projects/3680), Repo: https://github.com/exp10r3/nand_gate
+    - [ ] Test-ID: [3681](https://app.tinytapeout.com/projects/3681), Repo: https://github.com/mjuels/tinytapeoutworkshop
+    - [ ] Test-ID: [3686](https://app.tinytapeout.com/projects/3686), Repo: https://github.com/pablo-dk/TinyTapeoutDTU_chip
+    - [ ] Test-ID: [3687](https://app.tinytapeout.com/projects/3687), Repo: https://github.com/Abdulah-Korishe/Abdulah-s-1st-tiny-tapeout-design
+    - [ ] Test-ID: [3688](https://app.tinytapeout.com/projects/3688), Repo: https://github.com/jfho/tt-chip
+    - [ ] Test-ID: [3689](https://app.tinytapeout.com/projects/3689), Repo: https://github.com/McHerman/Tinytapeout
+    - [ ] Test-ID: [3691](https://app.tinytapeout.com/projects/3691), Repo: https://github.com/Sirius-DK/456571875721383937
+    - [ ] Test-ID: [3692](https://app.tinytapeout.com/projects/3692), Repo: https://github.com/Romultra/2-bit-adder-TTIHP26a
+    - [ ] Test-ID: [3693](https://app.tinytapeout.com/projects/3693), Repo: https://github.com/Niko78a1/tinytapeNK
+    - [ ] Test-ID: [3694](https://app.tinytapeout.com/projects/3694), Repo: https://github.com/SciFiCarrot/tiny-tapeout-workshop
+    - [ ] Test-ID: [3695](https://app.tinytapeout.com/projects/3695), Repo: https://github.com/Malthe2512/Tinytape
+    - [ ] Test-ID: [3696](https://app.tinytapeout.com/projects/3696), Repo: https://github.com/5gyyzwxbd4-svg/First
+    - [ ] Test-ID: [3698](https://app.tinytapeout.com/projects/3698), Repo: https://github.com/DragonDavid75/TinyTapeoutProjectWokwi
+    - [ ] Test-ID: [3699](https://app.tinytapeout.com/projects/3699), Repo: https://github.com/Skillygonzales/tiny_tapeout_demo
+    - [ ] Test-ID: [3700](https://app.tinytapeout.com/projects/3700), Repo: https://github.com/gusish89/tinytapeout_wokwi0
+    - [ ] Test-ID: [3701](https://app.tinytapeout.com/projects/3701), Repo: https://github.com/celien-14/cremedelacreme
+    - [ ] Test-ID: [3702](https://app.tinytapeout.com/projects/3702), Repo: https://github.com/AxuanW/wokwi-template
+    - [ ] Test-ID: [3703](https://app.tinytapeout.com/projects/3703), Repo: https://github.com/David-Weis/Wokwi-chip-design
+    - [ ] Test-ID: [3705](https://app.tinytapeout.com/projects/3705), Repo: https://github.com/carlhyldborglundstroem-code/TinyTapeoutCarlHL
+    - [ ] Test-ID: [3706](https://app.tinytapeout.com/projects/3706), Repo: https://github.com/giffel1/Scott-s-first-Wokwi-design
+    - [ ] Test-ID: [3708](https://app.tinytapeout.com/projects/3708), Repo: https://github.com/vntinas/My_Test_design
+    - [ ] Test-ID: [3712](https://app.tinytapeout.com/projects/3712), Repo: https://github.com/Ora-ng3/tiny-tapeout-basic
+    - [ ] Test-ID: [3713](https://app.tinytapeout.com/projects/3713), Repo: https://github.com/Jfvind/tt-jfvind
+    - [ ] Test-ID: [3714](https://app.tinytapeout.com/projects/3714), Repo: https://github.com/anilthilsted/tinytapeout_first
+    - [ ] Test-ID: [3715](https://app.tinytapeout.com/projects/3715), Repo: https://github.com/GustafsonA/TT26
+    - [ ] Test-ID: [3716](https://app.tinytapeout.com/projects/3716), Repo: https://github.com/Birkwk/Chip
+    - [ ] Test-ID: [3717](https://app.tinytapeout.com/projects/3717), Repo: https://github.com/HansAdam2077/ISC77x8
+    - [ ] Test-ID: [3718](https://app.tinytapeout.com/projects/3718), Repo: https://github.com/johannakin1/Hemmeligkode
+    - [ ] Test-ID: [3719](https://app.tinytapeout.com/projects/3719), Repo: https://github.com/Heinikm/TinyTapeout
+    - [ ] Test-ID: [3722](https://app.tinytapeout.com/projects/3722), Repo: https://github.com/donmonki/tt01_chip_design
+    - [ ] Test-ID: [3725](https://app.tinytapeout.com/projects/3725), Repo: https://github.com/YuriiPavlenko-DTU/FIRSTTEST
+    - [ ] Test-ID: [3728](https://app.tinytapeout.com/projects/3728), Repo: https://github.com/GitteBailey/TinyTapeoutWorkshop
+    - [ ] Test-ID: [3729](https://app.tinytapeout.com/projects/3729), Repo: https://github.com/martaalfonso/pomasic
+    - [ ] Test-ID: [3730](https://app.tinytapeout.com/projects/3730), Repo: https://github.com/kurimm/GitHub-Wokwi-Template
+    - [ ] Test-ID: [3731](https://app.tinytapeout.com/projects/3731), Repo: https://github.com/Nazgul-0/tinytapeoutGDS
+    - [ ] Test-ID: [3734](https://app.tinytapeout.com/projects/3734), Repo: https://github.com/tarkor111/tiny-tapeout-design
+    - [ ] Test-ID: [3735](https://app.tinytapeout.com/projects/3735), Repo: https://github.com/MikkelKofoed/TinyTapeoutWorkshop
+    - [ ] Test-ID: [3757](https://app.tinytapeout.com/projects/3757), Repo: https://github.com/crockpotveggies/neuron-ttihp
+    - [ ] Test-ID: [3763](https://app.tinytapeout.com/projects/3763), Repo: https://github.com/coastalwhite/tinytapeout-ihp-canright
+    - [ ] Test-ID: [3765](https://app.tinytapeout.com/projects/3765), Repo: https://github.com/ermalfierza1/E-Beam-Inspection-Pixel-Core
+    - [ ] Test-ID: [3766](https://app.tinytapeout.com/projects/3766), Repo: https://github.com/DelosReyesJordan/ttihp26a-FP8-SEM-Multiplier
+    - [ ] Test-ID: [3768](https://app.tinytapeout.com/projects/3768), Repo: https://github.com/intv0id/tt-ihp-TinyKalman
+    - [ ] Test-ID: [3769](https://app.tinytapeout.com/projects/3769), Repo: https://github.com/JPGHhb/ttihp-vga-tetris
+    - [ ] Test-ID: [3771](https://app.tinytapeout.com/projects/3771), Repo: https://github.com/Isk1337/Count-To-Ten
+    - [ ] Test-ID: [3772](https://app.tinytapeout.com/projects/3772), Repo: https://github.com/risc-v-wg/ttihp-26a-risc-v-wg-swc1
+    - [ ] Test-ID: [3775](https://app.tinytapeout.com/projects/3775), Repo: https://github.com/TechHU-GS/tt_rv32_trial
+    - [ ] Test-ID: [3948](https://app.tinytapeout.com/projects/3948), Repo: https://github.com/Neuromurf/ttihp26a-inferenceFCNN-16h3
+    - [ ] Test-ID: [3949](https://app.tinytapeout.com/projects/3949), Repo: https://github.com/obrhubr/ttihp-submission
+    - [ ] Test-ID: [3960](https://app.tinytapeout.com/projects/3960), Repo: https://github.com/anujic/anujic_ttihp26a (Skipped - Analog)
+    - [ ] Test-ID: [3974](https://app.tinytapeout.com/projects/3974), Repo: https://github.com/OzelHD/wokwi_test
+    - [ ] Test-ID: [3978](https://app.tinytapeout.com/projects/3978), Repo: https://github.com/libormiller/ttihp-simon
+    - [ ] Test-ID: [3979](https://app.tinytapeout.com/projects/3979), Repo: https://github.com/tschai-yim/ttihp-mill
+    - [ ] Test-ID: [3987](https://app.tinytapeout.com/projects/3987), Repo: https://github.com/gfcwfzkm/ttihp-scope (Skipped - Analog)
+    - [ ] Test-ID: [3988](https://app.tinytapeout.com/projects/3988), Repo: https://github.com/htfab/ttihp-microlane-demo
+    - [ ] Test-ID: [3991](https://app.tinytapeout.com/projects/3991), Repo: https://github.com/matei-coder/TinyTapeout-Processor2
+    - [ ] Test-ID: [3998](https://app.tinytapeout.com/projects/3998), Repo: https://github.com/RongGi/tiny_dino
+    - [ ] Test-ID: [3999](https://app.tinytapeout.com/projects/3999), Repo: https://github.com/splinedrive/kianv-sv32-tt-linux-soc
+    - [ ] Test-ID: [4002](https://app.tinytapeout.com/projects/4002), Repo: https://github.com/FilteredNoise/tt-infinity-core
+    - [ ] Test-ID: [4003](https://app.tinytapeout.com/projects/4003), Repo: https://github.com/alessio8132/IHP26a-4-bit-processor
+    - [ ] Test-ID: [4006](https://app.tinytapeout.com/projects/4006), Repo: https://github.com/GianmarcoFortunelli/TT_coprocessor
+    - [ ] Test-ID: [3778](https://app.tinytapeout.com/projects/3778), Repo: https://github.com/TechHU-GS/analog-trial (Skipped - Analog)
+    - [ ] Test-ID: [3523](https://app.tinytapeout.com/projects/3523), Repo: https://github.com/hoene/tt_um_hoene_firsttry (Skipped - Analog)
+    - [ ] Test-ID: [3758](https://app.tinytapeout.com/projects/3758), Repo: https://github.com/YannGuidon/miniMAC_tx
+
+- [ ] Add support for asynchronous signals (Planned)
+- [ ] Integrate with GHDL/Verilator for automated verification (Planned)
+- [ ] Integration with a simulator to verify test steps (Planned)
+- [ ] Improve documentation with examples (Planned)
+
+
+## Proposed
+- [ ] UI for defining test steps
+- [ ] Export to VHDL/Verilog testbench
+
 ## Finished
 - [x] Create simple testcase for Test-ID 3990 (OCP MXFP8 Streaming MAC Unit) (2026-03-15)
 - [x] Create simple testcase for Test-ID 3390 (mini mosbius) (Skipped - Analog / Not in shuttle ttihp26a) (2026-03-14)
@@ -73,101 +251,3 @@
 - [x] Define YAML schema for test steps (2025-05-22)
 - [x] Initial project structure created (2025-05-22)
 
-## Planned
-  - [ ] Create simple testcase for each assigned tile from TTIHP26A shuttle
-    - [x] Test-ID: [3546](https://app.tinytapeout.com/projects/3546), Repo: https://github.com/mlhktp/ttihp-wokwi (2025-05-23)
-    - [x] Test-ID: [3541](https://app.tinytapeout.com/projects/3541), Repo: https://github.com/zeynepdemirdag/tiny-tapeout-submission (2025-05-23)
-    - [x] Test-ID: [3564](https://app.tinytapeout.com/projects/3564), Repo: https://github.com/DeeJayTF/deejay-tinytapeout (2025-05-23)
-    - [x] Test-ID: [3657](https://app.tinytapeout.com/projects/3657), Repo: https://github.com/madsamtoft/TinyTapeout2 (2025-05-23)
-    - [x] Test-ID: [3674](https://app.tinytapeout.com/projects/3674), Repo: https://github.com/jonbng/tinytapeout-binary-to-7segment (2025-05-23)
-    - [x] Test-ID: [3723](https://app.tinytapeout.com/projects/3723), Repo: https://github.com/Ghunk09/ttworkshop_TEST (2025-05-23)
-    - [x] Test-ID: [3625](https://app.tinytapeout.com/projects/3625), Repo: https://github.com/terrywtr/Tianrui-Wang (2026-03-14)
-    - [ ] Test-ID: [3778](https://app.tinytapeout.com/projects/3778), Repo: https://github.com/TechHU-GS/analog-trial (Skipped - Analog)
-    - [x] Test-ID: [3577](https://app.tinytapeout.com/projects/3577), Repo: https://github.com/by-Tobd/tinytapeout (2026-03-14)
-    - [x] Test-ID: [3608](https://app.tinytapeout.com/projects/3608), Repo: https://github.com/TobisMa/GDS (2026-03-14)
-    - [x] Test-ID: [3679](https://app.tinytapeout.com/projects/3679), Repo: https://github.com/Maximillian-Udar/TT (2026-03-14)
-    - [x] Test-ID: [3697](https://app.tinytapeout.com/projects/3697), Repo: https://github.com/Daddybot/GDS (2026-03-14)
-    - [x] Test-ID: [3760](https://app.tinytapeout.com/projects/3760), Repo: https://github.com/brunny95/Genesis (Skipped - Analog) (2026-03-14)
-    - [x] Test-ID: [3704](https://app.tinytapeout.com/projects/3704), Repo: https://github.com/edga/tt_hello_gds (2026-03-14)
-    - [x] Test-ID: [3551](https://app.tinytapeout.com/projects/3551), Repo: https://github.com/sisarikaya/mytiny (2026-03-14)
-    - [x] Test-ID: [3666](https://app.tinytapeout.com/projects/3666), Repo: https://github.com/jonathan-farah/Sensors_and_Security (2026-03-14)
-    - [x] Test-ID: [3984](https://app.tinytapeout.com/projects/3984), Repo: https://github.com/gfcwfzkm/ttihp_opamp_bfh_gesep1_mht1_msm9 (Skipped - Analog) (2026-03-14)
-    - [x] Test-ID: [3685](https://app.tinytapeout.com/projects/3685), Repo: https://github.com/Paafu/Create-the-GDS (2026-03-14)
-    - [x] Test-ID: [3512](https://app.tinytapeout.com/projects/3512), Repo: https://github.com/danielowa/vga-tt (2026-03-14)
-    - [x] Test-ID: [3764](https://app.tinytapeout.com/projects/3764), Repo: https://github.com/BoredSemiRetiredEngineer/ttihp_submission_other_tile (2026-03-14)
-    - [x] Test-ID: [3762](https://app.tinytapeout.com/projects/3762), Repo: https://github.com/HecmacGPD/TTIHP-Hall-Sensor (Skipped - Analog) (2026-03-14)
-    - [x] Test-ID: [3665](https://app.tinytapeout.com/projects/3665), Repo: https://github.com/umn-geocommons/tt_um_teenyspu (2026-03-14)
-    - [x] Test-ID: [3684](https://app.tinytapeout.com/projects/3684), Repo: https://github.com/gcgc321/Tiny-Tapeout-Carry-Look-Ahead-Adder (2026-03-14)
-    - [x] Test-ID: [3720](https://app.tinytapeout.com/projects/3720), Repo: https://github.com/edwar1r/TinyTapeoutCopenhagenFeb2026 (2026-03-14)
-    - [x] Test-ID: [3647](https://app.tinytapeout.com/projects/3647), Repo: https://github.com/Essenceia/Systolic_Array_with_DFT_v2 (2026-03-14)
-    - [x] Test-ID: [3614](https://app.tinytapeout.com/projects/3614), Repo: https://github.com/nusli7/TT-Project (2026-03-14)
-    - [x] Test-ID: [3711](https://app.tinytapeout.com/projects/3711), Repo: https://github.com/ds-anik/Tiny-Tapeout (2026-03-14)
-    - [x] Test-ID: [3603](https://app.tinytapeout.com/projects/3603), Repo: https://github.com/XxFanny17xX/tinytapeoutFY (2026-03-14)
-    - [x] Test-ID: [3737](https://app.tinytapeout.com/projects/3737), Repo: https://github.com/ChiranjitPatel/tt_ihp26a_ringosc_stdcell (2026-03-14)
-    - [x] Test-ID: [3957](https://app.tinytapeout.com/projects/3957), Repo: https://github.com/michaelstambach/vogal (2026-03-14)
-    - [x] Test-ID: [3638](https://app.tinytapeout.com/projects/3638), Repo: https://github.com/zouzias/ttihp-verilog-eth (2026-03-14)
-    - [x] Test-ID: [3556](https://app.tinytapeout.com/projects/3556), Repo: https://github.com/Duwandervall/yturkeri_mytinytapeout (2026-03-14)
-    - [ ] Test-ID: [3523](https://app.tinytapeout.com/projects/3523), Repo: https://github.com/hoene/tt_um_hoene_firsttry (Skipped - Analog)
-    - [x] Test-ID: [3587](https://app.tinytapeout.com/projects/3587), Repo: https://github.com/lriglooC/tiny-tapeout-first-design (2026-03-14)
-    - [x] Test-ID: [3581](https://app.tinytapeout.com/projects/3581), Repo: https://github.com/vlad-penchev/tinytapeoutz (2026-03-14)
-    - [x] Test-ID: [3970](https://app.tinytapeout.com/projects/3970), Repo: https://github.com/TscherterJunior/tt_um_TscherterJunior_top (2026-03-14)
-    - [x] Test-ID: [3724](https://app.tinytapeout.com/projects/3724), Repo: https://github.com/shreeveni-x90/SREE (2026-03-14)
-    - [x] Test-ID: [3538](https://app.tinytapeout.com/projects/3538), Repo: https://github.com/mohamedelsharkawy101/tinytapout_test (2026-03-14)
-    - [x] Test-ID: [3759](https://app.tinytapeout.com/projects/3759), Repo: https://github.com/jalcim/ttihp-jalcim_ihp_analog_tester (2026-03-14)
-    - [x] Test-ID: [3609](https://app.tinytapeout.com/projects/3609), Repo: https://github.com/tippfehlr/tinytapeout (2026-03-14)
-    - [x] Test-ID: [3707](https://app.tinytapeout.com/projects/3707), Repo: https://github.com/skippersboat/tinytapeout_create_your_gds (2026-03-14)
-    - [x] Test-ID: [3618](https://app.tinytapeout.com/projects/3618), Repo: https://github.com/BenediktKeppner/tt-verilog (2026-03-14)
-    - [x] Test-ID: [3975](https://app.tinytapeout.com/projects/3975), Repo: https://github.com/znah/ihp-ca (2026-03-14)
-    - [x] Test-ID: [3726](https://app.tinytapeout.com/projects/3726), Repo: https://github.com/EhsanKhodadad/ttihp-wokwi (2026-03-14)
-    - [x] Test-ID: [3662](https://app.tinytapeout.com/projects/3662), Repo: https://github.com/YashKarthik/ttihp-counter (2026-03-14)
-    - [x] Test-ID: [3682](https://app.tinytapeout.com/projects/3682), Repo: https://github.com/vermiscore/ttihp26a-i2c-spi-bridge (2026-03-14)
-    - [x] Test-ID: [3534](https://app.tinytapeout.com/projects/3534), Repo: https://github.com/pranav0x0112/ttihp26a-Herald (2026-03-14)
-    - [x] Test-ID: [3565](https://app.tinytapeout.com/projects/3565), Repo: https://github.com/leo0111001/TTIHP26a-FH-Joanneum (2026-03-14)
-    - [x] Test-ID: [3489](https://app.tinytapeout.com/projects/3489), Repo: https://github.com/rejunity/ttihp26a-vga-tiny-logo-rotozoomer (2026-03-14)
-    - [x] Test-ID: [3491](https://app.tinytapeout.com/projects/3491), Repo: https://github.com/RebeccaRGB/ttihp-ubcd (2026-03-14)
-    - [x] Test-ID: [3492](https://app.tinytapeout.com/projects/3492), Repo: https://github.com/RebeccaRGB/ttihp-hardware-utf8 (2026-03-14)
-    - [x] Test-ID: [3493](https://app.tinytapeout.com/projects/3493), Repo: https://github.com/RebeccaRGB/ttihp-intercal-alu (2026-03-14)
-    - [x] Test-ID: [3494](https://app.tinytapeout.com/projects/3494), Repo: https://github.com/RebeccaRGB/ttihp-vga-pride (2026-03-14)
-    - [x] Test-ID: [3495](https://app.tinytapeout.com/projects/3495), Repo: https://github.com/urish/tt-simon-game (2026-03-14)
-    - [x] Test-ID: [3497](https://app.tinytapeout.com/projects/3497), Repo: https://github.com/dxa4481/tiny (2026-03-14)
-    - [x] Test-ID: [3498](https://app.tinytapeout.com/projects/3498), Repo: https://github.com/adityapundir1985/tt_um_aksp_mbist_mbisr (2026-03-14)
-    - [x] Test-ID: [3503](https://app.tinytapeout.com/projects/3503), Repo: https://github.com/aakarsh1011/tiny-tapeout (2026-03-14)
-    - [x] Test-ID: [3504](https://app.tinytapeout.com/projects/3504), Repo: https://github.com/hemanthkrishna5/tiny_tape_out (2026-03-14)
-    - [x] Test-ID: [3506](https://app.tinytapeout.com/projects/3506), Repo: https://github.com/danielowa/tt-wokwi (2026-03-14)
-    - [x] Test-ID: [3505](https://app.tinytapeout.com/projects/3505), Repo: https://github.com/tulrich2/TinyTapeout (2026-03-14)
-    - [x] Test-ID: [3508](https://app.tinytapeout.com/projects/3508), Repo: https://github.com/potatojuicemachine/tiny-tapeout (2026-03-14)
-    - [x] Test-ID: [3507](https://app.tinytapeout.com/projects/3507), Repo: https://github.com/mbdaneshvar/mo_tapeout (2026-03-14)
-    - [x] Test-ID: [3510](https://app.tinytapeout.com/projects/3510), Repo: https://github.com/tulrich2/ttihp-verilog (2026-03-14)
-    - [x] Test-ID: [3509](https://app.tinytapeout.com/projects/3509), Repo: https://github.com/potatojuicemachine/vga-tt (2026-03-14)
-    - [x] Test-ID: [3511](https://app.tinytapeout.com/projects/3511), Repo: https://github.com/mbdaneshvar/sv_tapeout (2026-03-14)
-    - [x] Test-ID: [3514](https://app.tinytapeout.com/projects/3514), Repo: https://github.com/StaCu/ttihp-snake-game (2026-03-14)
-    - [x] Test-ID: [3515](https://app.tinytapeout.com/projects/3515), Repo: https://github.com/yuya0421/tt_ihp_cic_filter (2026-03-14)
-    - [x] Test-ID: [3519](https://app.tinytapeout.com/projects/3519), Repo: https://github.com/xzackli/ttihp-verilog-spi-aggregator (2026-03-14)
-    - [x] Test-ID: [3486](https://app.tinytapeout.com/projects/3486), Repo: https://github.com/TinyTapeout/tt-chip-rom (2026-03-14)
-    - [x] Test-ID: [3487](https://app.tinytapeout.com/projects/3487), Repo: https://github.com/TinyTapeout/ttihp26a-factory-test (2026-03-14)
-    - [x] Test-ID: [3499](https://app.tinytapeout.com/projects/3499), Repo: https://github.com/urish/ttihp-oscillating-bones (Skipped - Analog) (2026-03-14)
-    - [x] Test-ID: [3524](https://app.tinytapeout.com/projects/3524), Repo: https://github.com/pacalodu/tinytapeout (2026-03-14)
-    - [x] Test-ID: [3526](https://app.tinytapeout.com/projects/3526), Repo: https://github.com/floAfentaki/tinyTapeVerilog_out (2026-03-14)
-    - [x] Test-ID: [3709](https://app.tinytapeout.com/projects/3709), Repo: https://github.com/lucapezza/ttIHP26a_luke_meta (2026-03-14)
-    - [x] Test-ID: [3710](https://app.tinytapeout.com/projects/3710), Repo: https://github.com/schoeberl/ttihp-undecided (2026-03-14)
-    - [x] Test-ID: [3733](https://app.tinytapeout.com/projects/3733), Repo: https://github.com/hoene/tt_um_hoene_smart_led_digital (2026-03-14)
-    - [x] Test-ID: [3736](https://app.tinytapeout.com/projects/3736), Repo: https://github.com/flummer/tt-um-flummer-ltc (2026-03-14)
-    - [x] Test-ID: [3738](https://app.tinytapeout.com/projects/3738), Repo: https://github.com/chrbirks/tt-2026 (2026-03-14)
-    - [x] Test-ID: [3740](https://app.tinytapeout.com/projects/3740), Repo: https://github.com/jalcim/tiny_tester (2026-03-14)
-    - [x] Test-ID: [3743](https://app.tinytapeout.com/projects/3743), Repo: https://github.com/SiliconPlatformsLab/wedgetail-tester-tt-ihp26a (2026-03-14)
-    - [x] Test-ID: [3744](https://app.tinytapeout.com/projects/3744), Repo: https://github.com/mole99/tt-fabulous-ihp-26a (2026-03-14)
-    - [x] Test-ID: [3745](https://app.tinytapeout.com/projects/3745), Repo: https://github.com/alokerdas/tt_um_ihp26a_LnL_SoC (2026-03-14)
-    - [x] Test-ID: [3747](https://app.tinytapeout.com/projects/3747), Repo: https://github.com/ygdes/ttihp-HDSISO8 (2026-03-14)
-    - [x] Test-ID: [3750](https://app.tinytapeout.com/projects/3750), Repo: https://github.com/sunny441/ttihp26a-adex-neuron-ncs (Skipped - Analog) (2026-03-14)
-    - [x] Test-ID: [3753](https://app.tinytapeout.com/projects/3753), Repo: https://github.com/algofoogle/ttihp26a-fomo (2026-03-14)
-    - [x] Test-ID: [3756](https://app.tinytapeout.com/projects/3756), Repo: https://github.com/MichaelBell/ttihp26a-photo-frame (2026-03-14)
-    - [ ] Test-ID: [3758](https://app.tinytapeout.com/projects/3758), Repo: https://github.com/YannGuidon/miniMAC_tx
-
-- [ ] Add support for asynchronous signals (Planned)
-- [ ] Integrate with GHDL/Verilator for automated verification (Planned)
-- [ ] Integration with a simulator to verify test steps (Planned)
-- [ ] Improve documentation with examples (Planned)
-
-## Proposed
-- [ ] UI for defining test steps
-- [ ] Export to VHDL/Verilog testbench


### PR DESCRIPTION
This submission reorganizes the `ROADMAP.md` file by moving the `## Finished` section to the bottom and populating the `## Planned` section with all missing projects from the TTIHP26A shuttle. 

Key changes include:
1.  **Reorganization**: The section order is now `## Planned`, `## Proposed`, and `## Finished`.
2.  **Shuttle Projects**: Automated retrieval of project details for 162 missing IDs using the provided scripts.
3.  **Refinement**: Analog projects are automatically identified and marked as skipped.
4.  **Deduplication**: Redundant entries for completed tasks were removed from the `## Planned` sub-list to keep the roadmap concise and professional.
5.  **Repository Hygiene**: All temporary scripts and data files used during the process have been deleted.

Project tests passed, and the roadmap formatting has been verified.

Fixes #50

---
*PR created automatically by Jules for task [2999498790409824937](https://jules.google.com/task/2999498790409824937) started by @chatelao*