### PR TITLE
Add Project Documentation Summaries

### DIFF
--- a/projects/tt3400.md
+++ b/projects/tt3400.md
@@ -1,0 +1,19 @@
+# FIR Filter
+
+**Source:** [https://github.com/hammal/vhdl_filter](https://github.com/hammal/vhdl_filter)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3400](https://app.tinytapeout.com/projects/3400)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3400_fir_filter.svg)

--- a/projects/tt3404.md
+++ b/projects/tt3404.md
@@ -1,0 +1,18 @@
+# Verilog Multistage Oscillator with Enable and Counter
+
+**Source:** [https://github.com/RemingtonHolder/tapeout_verilog](https://github.com/RemingtonHolder/tapeout_verilog)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3404](https://app.tinytapeout.com/projects/3404)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| TAPS | input | 3 |
+| OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3404_oscillator.svg)

--- a/projects/tt3405.md
+++ b/projects/tt3405.md
@@ -1,0 +1,17 @@
+# My (S)VGA Playground
+
+**Source:** [https://github.com/rejunity/tt-vga-sandbox](https://github.com/rejunity/tt-vga-sandbox)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3405](https://app.tinytapeout.com/projects/3405)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3405_vga_playground.svg)

--- a/projects/tt3409.md
+++ b/projects/tt3409.md
@@ -1,0 +1,18 @@
+# xorshift
+
+**Source:** [https://github.com/oscargus/byggenchip](https://github.com/oscargus/byggenchip)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3409](https://app.tinytapeout.com/projects/3409)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3409_xorshift.svg)

--- a/projects/tt3410.md
+++ b/projects/tt3410.md
@@ -1,0 +1,18 @@
+# Counter
+
+**Source:** [https://github.com/oscargus/ttsky-vhdl-makeAchip-izaha684](https://github.com/oscargus/ttsky-vhdl-makeAchip-izaha684)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3410](https://app.tinytapeout.com/projects/3410)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3410_counter.svg)

--- a/projects/tt3415.md
+++ b/projects/tt3415.md
@@ -1,0 +1,19 @@
+# SimProc (Simple Processor)
+
+**Source:** [https://github.com/ieeeuoft-asic/simproc](https://github.com/ieeeuoft-asic/simproc)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3415](https://app.tinytapeout.com/projects/3415)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3415_simproc.svg)

--- a/projects/tt3417.md
+++ b/projects/tt3417.md
@@ -1,0 +1,16 @@
+# NCO
+
+**Source:** [https://github.com/pantelis300/tt_um_pantelis300_nco](https://github.com/pantelis300/tt_um_pantelis300_nco)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3417](https://app.tinytapeout.com/projects/3417)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0:7] | input | 8 |
+| uo[0:7] | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3417_nco.svg)

--- a/projects/tt3420.md
+++ b/projects/tt3420.md
@@ -1,0 +1,19 @@
+# KianV RISC-V RV32E Baremetal SoC
+
+**Source:** [https://github.com/by17s/RISCV-KianV-BareMetalStyle](https://github.com/by17s/RISCV-KianV-BareMetalStyle)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3420](https://app.tinytapeout.com/projects/3420)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3420_kianv_rv32e.svg)

--- a/projects/tt3422.md
+++ b/projects/tt3422.md
@@ -1,0 +1,18 @@
+# Morse Code Detector (With Serial RX)
+
+**Source:** [https://github.com/KerCrafter/morse_code_tto](https://github.com/KerCrafter/morse_code_tto)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3422](https://app.tinytapeout.com/projects/3422)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0] | input | 1 |
+| ui[1] | input | 1 |
+| ui[2] | input | 1 |
+| uo[0:7] | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3422_morse_detector.svg)

--- a/projects/tt3425.md
+++ b/projects/tt3425.md
@@ -1,0 +1,18 @@
+# 2048 sliding tile puzzle game (VGA)
+
+**Source:** [https://github.com/urish/tt-2048-game](https://github.com/urish/tt-2048-game)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3425](https://app.tinytapeout.com/projects/3425)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3425_vga_2048.svg)

--- a/projects/tt3430.md
+++ b/projects/tt3430.md
@@ -1,0 +1,20 @@
+# Classic 8-bit era Programmable Sound Generator SN76489
+
+**Source:** [https://github.com/rejunity/tt05-psg-sn76489](https://github.com/rejunity/tt05-psg-sn76489)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3430](https://app.tinytapeout.com/projects/3430)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| uio_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3430_sn76489.svg)

--- a/projects/tt3432.md
+++ b/projects/tt3432.md
@@ -1,0 +1,20 @@
+# Wafer.space Logo VGA Screensaver
+
+**Source:** [https://github.com/TinyTapeout/tt-waferspace-vga-screensaver](https://github.com/TinyTapeout/tt-waferspace-vga-screensaver)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3432](https://app.tinytapeout.com/projects/3432)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0] | input | 1 |
+| ui[1] | input | 1 |
+| uo[3] | output | 1 |
+| uo[7] | output | 1 |
+| uo[4:6] | output | 3 |
+| uo[0:2] | output | 3 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3432_vga_screensaver.svg)

--- a/projects/tt3434.md
+++ b/projects/tt3434.md
@@ -1,0 +1,31 @@
+# Zilog Z80
+
+**Source:** [https://github.com/rejunity/z80-open-silicon](https://github.com/rejunity/z80-open-silicon)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3434](https://app.tinytapeout.com/projects/3434)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| WAIT_N | input | 1 |
+| INT_N | input | 1 |
+| NMI_N | input | 1 |
+| BUSRQ_N | input | 1 |
+| CONFIG | input | 2 |
+| MUX | input | 2 |
+| M1_A0 | output | 1 |
+| MREQ_A1 | output | 1 |
+| IORQ_A2 | output | 1 |
+| RD_A3 | output | 1 |
+| WR_A4 | output | 1 |
+| RFSH_A5 | output | 1 |
+| HALT_A6 | output | 1 |
+| BUSAK_A7 | output | 1 |
+| DATA | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3434_z80.svg)

--- a/projects/tt3435.md
+++ b/projects/tt3435.md
@@ -1,0 +1,19 @@
+# TinyQV Risc-V SoC
+
+**Source:** [https://github.com/MichaelBell/ttgf0p2-tinyQV](https://github.com/MichaelBell/ttgf0p2-tinyQV)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3435](https://app.tinytapeout.com/projects/3435)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3435_tinyqv.svg)

--- a/projects/tt3437.md
+++ b/projects/tt3437.md
@@ -1,0 +1,18 @@
+# Simon's Caterpillar
+
+**Source:** [https://github.com/htfab/ttgf0p2-caterpillar](https://github.com/htfab/ttgf0p2-caterpillar)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3437](https://app.tinytapeout.com/projects/3437)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0:3] | input | 4 |
+| uo[0:3] | output | 4 |
+| uo[5:6] | output | 2 |
+| uio[0:6] | output | 7 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3437_caterpillar.svg)

--- a/projects/tt3439.md
+++ b/projects/tt3439.md
@@ -1,0 +1,19 @@
+# Cell mux
+
+**Source:** [https://github.com/htfab/ttgf0p2-cells](https://github.com/htfab/ttgf0p2-cells)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3439](https://app.tinytapeout.com/projects/3439)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| PAGE | input | 5 |
+| IN | input | 3 |
+| OUT | output | 8 |
+| IN35 | inout | 3 |
+| EN_TRI | inout | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3439_cell_mux.svg)

--- a/projects/tt3440.md
+++ b/projects/tt3440.md
@@ -1,0 +1,18 @@
+# Zedulo TestChip1
+
+**Source:** [https://github.com/ZeduloTech/ttgf-zed_tc1](https://github.com/ZeduloTech/ttgf-zed_tc1)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3440](https://app.tinytapeout.com/projects/3440)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3440_zedtc1.svg)

--- a/projects/tt3445.md
+++ b/projects/tt3445.md
@@ -1,0 +1,19 @@
+# Wildcat RISC-V
+
+**Source:** [https://github.com/schoeberl/ttgf-wildcat](https://github.com/schoeberl/ttgf-wildcat)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3445](https://app.tinytapeout.com/projects/3445)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3445_wildcat.svg)

--- a/projects/tt3449.md
+++ b/projects/tt3449.md
@@ -1,0 +1,22 @@
+# VGA Drop (audio/visual demo)
+
+**Source:** [https://github.com/rejunity/tt08-vga-drop](https://github.com/rejunity/tt08-vga-drop)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3449](https://app.tinytapeout.com/projects/3449)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| R | output | 2 |
+| G | output | 2 |
+| B | output | 2 |
+| VSYNC | output | 1 |
+| HSYNC | output | 1 |
+| AUDIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3449_vga_drop.svg)

--- a/projects/tt3454.md
+++ b/projects/tt3454.md
@@ -1,0 +1,23 @@
+# MarcoPolo
+
+**Source:** [https://github.com/javiBajoCero/ttgf-verilog-template](https://github.com/javiBajoCero/ttgf-verilog-template)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3454](https://app.tinytapeout.com/projects/3454)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UART_RX | input | 1 |
+| UART_TX | output | 1 |
+| TICK_RX | output | 1 |
+| TICK_TX | output | 1 |
+| TRIG | output | 1 |
+| BUSY | output | 1 |
+| LED | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3454_marcopolo.svg)

--- a/projects/tt3462.md
+++ b/projects/tt3462.md
@@ -1,0 +1,19 @@
+# Frequency Counter SSD1306 OLED
+
+**Source:** [https://github.com/embelon/ttgf-frequency-counter-oled](https://github.com/embelon/ttgf-frequency-counter-oled)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3462](https://app.tinytapeout.com/projects/3462)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0] | input | 1 |
+| uo[0] | output | 1 |
+| uo[3] | output | 1 |
+| uo[5] | output | 1 |
+| uo[6] | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3462_freq_counter.svg)

--- a/projects/tt3477.md
+++ b/projects/tt3477.md
@@ -1,0 +1,19 @@
+# Flame demo
+
+**Source:** [https://github.com/kbeckmann/ttgf0p2-kbeckmann-flame](https://github.com/kbeckmann/ttgf0p2-kbeckmann-flame)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3477](https://app.tinytapeout.com/projects/3477)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| uo[3] | output | 1 |
+| uo[7] | output | 1 |
+| uo[4:6] | output | 3 |
+| uo[0:2] | output | 3 |
+| uio[7] | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3477_flame_demo.svg)

--- a/projects/tt3486.md
+++ b/projects/tt3486.md
@@ -1,0 +1,16 @@
+# Chip ROM
+
+**Source:** [https://github.com/TinyTapeout/tt-chip-rom](https://github.com/TinyTapeout/tt-chip-rom)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3486](https://app.tinytapeout.com/projects/3486)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3486_chip_rom.svg)

--- a/projects/tt3487.md
+++ b/projects/tt3487.md
@@ -1,0 +1,20 @@
+# Tiny Tapeout Factory Test
+
+**Source:** [https://github.com/TinyTapeout/ttihp26a-factory-test](https://github.com/TinyTapeout/ttihp26a-factory-test)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3487](https://app.tinytapeout.com/projects/3487)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO_IN | input | 8 |
+| UIO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3487_factory_test.svg)

--- a/projects/tt3489.md
+++ b/projects/tt3489.md
@@ -1,0 +1,16 @@
+# VGA Tiny Logo Roto Zoomer
+
+**Source:** [https://github.com/rejunity/ttihp26a-vga-tiny-logo-rotozoomer](https://github.com/rejunity/ttihp26a-vga-tiny-logo-rotozoomer)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3489](https://app.tinytapeout.com/projects/3489)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3489_vga_roto.svg)

--- a/projects/tt3491.md
+++ b/projects/tt3491.md
@@ -1,0 +1,17 @@
+# Universal Binary to Segment Decoder
+
+**Source:** [https://github.com/RebeccaRGB/ttihp-ubcd](https://github.com/RebeccaRGB/ttihp-ubcd)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3491](https://app.tinytapeout.com/projects/3491)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3491_ubcd.svg)

--- a/projects/tt3492.md
+++ b/projects/tt3492.md
@@ -1,0 +1,17 @@
+# Hardware UTF Encoder/Decoder
+
+**Source:** [https://github.com/RebeccaRGB/ttihp-hardware-utf8](https://github.com/RebeccaRGB/ttihp-hardware-utf8)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3492](https://app.tinytapeout.com/projects/3492)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3492_utf8.svg)

--- a/projects/tt3493.md
+++ b/projects/tt3493.md
@@ -1,0 +1,17 @@
+# INTERCAL ALU
+
+**Source:** [https://github.com/RebeccaRGB/ttihp-intercal-alu](https://github.com/RebeccaRGB/ttihp-intercal-alu)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3493](https://app.tinytapeout.com/projects/3493)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3493_intercal_alu.svg)

--- a/projects/tt3494.md
+++ b/projects/tt3494.md
@@ -1,0 +1,16 @@
+# VGA Pride
+
+**Source:** [https://github.com/RebeccaRGB/ttihp-vga-pride](https://github.com/RebeccaRGB/ttihp-vga-pride)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3494](https://app.tinytapeout.com/projects/3494)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3494_vga_pride.svg)

--- a/projects/tt3495.md
+++ b/projects/tt3495.md
@@ -1,0 +1,17 @@
+# Simon Says memory game
+
+**Source:** [https://github.com/urish/tt-simon-game](https://github.com/urish/tt-simon-game)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3495](https://app.tinytapeout.com/projects/3495)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3495_simon.svg)

--- a/projects/tt3497.md
+++ b/projects/tt3497.md
@@ -1,0 +1,16 @@
+# Silicon Art - Pixel Pig + Canary Token
+
+**Source:** [https://github.com/dxa4481/tiny](https://github.com/dxa4481/tiny)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3497](https://app.tinytapeout.com/projects/3497)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3497_art.svg)

--- a/projects/tt3498.md
+++ b/projects/tt3498.md
@@ -1,0 +1,16 @@
+# MBIST + MBISR Built-In Memory Test & Repair
+
+**Source:** [https://github.com/adityapundir1985/tt_um_aksp_mbist_mbisr](https://github.com/adityapundir1985/tt_um_aksp_mbist_mbisr)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3498](https://app.tinytapeout.com/projects/3498)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3498_mbist.svg)

--- a/projects/tt3502.md
+++ b/projects/tt3502.md
@@ -1,0 +1,18 @@
+# Herald
+
+**Source:** [https://github.com/pranav0x0112/ttihp26a-Herald](https://github.com/pranav0x0112/ttihp26a-Herald)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3502](https://app.tinytapeout.com/projects/3502)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3502_herald.svg)

--- a/projects/tt3503.md
+++ b/projects/tt3503.md
@@ -1,0 +1,16 @@
+# RandomNum
+
+**Source:** [https://github.com/aakarsh1011/tiny-tapeout](https://github.com/aakarsh1011/tiny-tapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3503](https://app.tinytapeout.com/projects/3503)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3503_randomnum.svg)

--- a/projects/tt3504.md
+++ b/projects/tt3504.md
@@ -1,0 +1,16 @@
+# test
+
+**Source:** [https://github.com/hemanthkrishna5/tiny_tape_out](https://github.com/hemanthkrishna5/tiny_tape_out)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3504](https://app.tinytapeout.com/projects/3504)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3504_test.svg)

--- a/projects/tt3505.md
+++ b/projects/tt3505.md
@@ -1,0 +1,16 @@
+# TinyTapeout test
+
+**Source:** [https://github.com/tulrich2/TinyTapeout](https://github.com/tulrich2/TinyTapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3505](https://app.tinytapeout.com/projects/3505)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3505_test.svg)

--- a/projects/tt3506.md
+++ b/projects/tt3506.md
@@ -1,0 +1,16 @@
+# Snake
+
+**Source:** [https://github.com/danielowa/tt-wokwi](https://github.com/danielowa/tt-wokwi)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3506](https://app.tinytapeout.com/projects/3506)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3506_snake.svg)

--- a/projects/tt3507.md
+++ b/projects/tt3507.md
@@ -1,0 +1,16 @@
+# test_prj
+
+**Source:** [https://github.com/mbdaneshvar/mo_tapeout](https://github.com/mbdaneshvar/mo_tapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3507](https://app.tinytapeout.com/projects/3507)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3507_test_prj.svg)

--- a/projects/tt3508.md
+++ b/projects/tt3508.md
@@ -1,0 +1,16 @@
+# Tadder
+
+**Source:** [https://github.com/potatojuicemachine/tiny-tapeout](https://github.com/potatojuicemachine/tiny-tapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3508](https://app.tinytapeout.com/projects/3508)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3508_tadder.svg)

--- a/projects/tt3509.md
+++ b/projects/tt3509.md
@@ -1,0 +1,16 @@
+# Silly Dog
+
+**Source:** [https://github.com/potatojuicemachine/vga-tt](https://github.com/potatojuicemachine/vga-tt)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3509](https://app.tinytapeout.com/projects/3509)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3509_silly_dog.svg)

--- a/projects/tt3510.md
+++ b/projects/tt3510.md
@@ -1,0 +1,16 @@
+# Not a Dinosaur
+
+**Source:** [https://github.com/tulrich2/ttihp-verilog](https://github.com/tulrich2/ttihp-verilog)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3510](https://app.tinytapeout.com/projects/3510)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3510_dino.svg)

--- a/projects/tt3511.md
+++ b/projects/tt3511.md
@@ -1,0 +1,16 @@
+# vga test project
+
+**Source:** [https://github.com/mbdaneshvar/sv_tapeout](https://github.com/mbdaneshvar/sv_tapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3511](https://app.tinytapeout.com/projects/3511)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3511_vga_test.svg)

--- a/projects/tt3512.md
+++ b/projects/tt3512.md
@@ -1,0 +1,16 @@
+# Silly Dog VGA
+
+**Source:** [https://github.com/danielowa/vga-tt](https://github.com/danielowa/vga-tt)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3512](https://app.tinytapeout.com/projects/3512)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3512_vga.svg)

--- a/projects/tt3514.md
+++ b/projects/tt3514.md
@@ -1,0 +1,17 @@
+# SnakeGame
+
+**Source:** [https://github.com/StaCu/ttihp-snake-game](https://github.com/StaCu/ttihp-snake-game)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3514](https://app.tinytapeout.com/projects/3514)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3514_snake_game.svg)

--- a/projects/tt3515.md
+++ b/projects/tt3515.md
@@ -1,0 +1,16 @@
+# Discrete-to-ASIC Delta-Sigma Acquisition System
+
+**Source:** [https://github.com/yuya0421/tt_ihp_cic_filter](https://github.com/yuya0421/tt_ihp_cic_filter)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3515](https://app.tinytapeout.com/projects/3515)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3515_cic_filter.svg)

--- a/projects/tt3519.md
+++ b/projects/tt3519.md
@@ -1,0 +1,17 @@
+# Quad SPI Aggregator
+
+**Source:** [https://github.com/xzackli/ttihp-verilog-spi-aggregator](https://github.com/xzackli/ttihp-verilog-spi-aggregator)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3519](https://app.tinytapeout.com/projects/3519)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3519_spi_aggregator.svg)

--- a/projects/tt3522.md
+++ b/projects/tt3522.md
@@ -1,0 +1,20 @@
+# Tiny D-Cache
+
+**Source:** [https://github.com/Niels5931/ttihp_simple_dcache](https://github.com/Niels5931/ttihp_simple_dcache)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3522](https://app.tinytapeout.com/projects/3522)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0:3] | input | 4 |
+| ui[4] | input | 1 |
+| ui[5] | input | 1 |
+| uo[4] | output | 1 |
+| uo[5] | output | 1 |
+| uo[0:3] | output | 4 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3522_dcache.svg)

--- a/projects/tt3524.md
+++ b/projects/tt3524.md
@@ -1,0 +1,16 @@
+# Digital Lock with Easter Eggs
+
+**Source:** [https://github.com/pacalodu/tinytapeout](https://github.com/pacalodu/tinytapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3524](https://app.tinytapeout.com/projects/3524)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3524_digital_lock.svg)

--- a/projects/tt3526.md
+++ b/projects/tt3526.md
@@ -1,0 +1,18 @@
+# tinyTapeVerilog_out
+
+**Source:** [https://github.com/floAfentaki/tinyTapeVerilog_out](https://github.com/floAfentaki/tinyTapeVerilog_out)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3526](https://app.tinytapeout.com/projects/3526)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| ENA | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3526_counter.svg)

--- a/projects/tt3528.md
+++ b/projects/tt3528.md
@@ -1,0 +1,27 @@
+# m6502 Microcontroller
+
+**Source:** [https://github.com/chrismoos/tt-led-controller](https://github.com/chrismoos/tt-led-controller)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3528](https://app.tinytapeout.com/projects/3528)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| MUX_SEL | input | 2 |
+| RDY | input | 1 |
+| NMI_N | input | 1 |
+| IRQ_N | input | 1 |
+| SO_N | input | 1 |
+| GPIOA | inout | 6 |
+| PHI1 | output | 1 |
+| PHI2 | output | 1 |
+| RW | output | 1 |
+| SYNC | output | 1 |
+| MUX_DATA | inout | 8 |
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3528_m6502.svg)

--- a/projects/tt3531.md
+++ b/projects/tt3531.md
@@ -1,0 +1,23 @@
+# FH Joanneum TinyTapeout
+
+**Source:** [https://github.com/Electronic-and-Computer-Engineering/TT_IHP26a_FH_uC](https://github.com/Electronic-and-Computer-Engineering/TT_IHP26a_FH_uC)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3531](https://app.tinytapeout.com/projects/3531)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| SPI_MISO | input | 1 |
+| GPIO_IN | input | 4 |
+| SPI_MOSI | output | 1 |
+| SPI_CLK | output | 1 |
+| SPI_CS1_N | output | 1 |
+| SPI_CS2_N | output | 1 |
+| GPIO_OUT | output | 4 |
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3531_fh_uc.svg)

--- a/projects/tt3533.md
+++ b/projects/tt3533.md
@@ -1,0 +1,18 @@
+# Piggybag
+
+**Source:** [https://github.com/Fing2525/piggy_bag](https://github.com/Fing2525/piggy_bag)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3533](https://app.tinytapeout.com/projects/3533)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3533_piggybag.svg)

--- a/projects/tt3534.md
+++ b/projects/tt3534.md
@@ -1,0 +1,17 @@
+# TinyTapeOut_gate
+
+**Source:** [https://github.com/henrikscheidt99/tinytapeout](https://github.com/henrikscheidt99/tinytapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3534](https://app.tinytapeout.com/projects/3534)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| A | input | 1 |
+| B | input | 1 |
+| OUT | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3534_gate.svg)

--- a/projects/tt3537.md
+++ b/projects/tt3537.md
@@ -1,0 +1,17 @@
+# 6 Bit Roulette
+
+**Source:** [https://github.com/svens0210/Roulette_Game](https://github.com/svens0210/Roulette_Game)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3537](https://app.tinytapeout.com/projects/3537)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UO_OUT | output | 8 |
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3537_roulette.svg)

--- a/projects/tt3538.md
+++ b/projects/tt3538.md
@@ -1,0 +1,18 @@
+# tinytapout_test
+
+**Source:** [https://wokwi.com/projects/354858054593504257](https://wokwi.com/projects/354858054593504257)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3538](https://app.tinytapeout.com/projects/3538)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3538_tinytapout_test.svg)

--- a/projects/tt3539.md
+++ b/projects/tt3539.md
@@ -1,0 +1,21 @@
+# secretNo
+
+**Source:** [https://github.com/thravax/tt-test](https://github.com/thravax/tt-test)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3539](https://app.tinytapeout.com/projects/3539)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| INPUT_A | input | 1 |
+| INPUT_B | input | 1 |
+| INPUT_C | input | 1 |
+| INPUT_D | input | 1 |
+| UO_OUT | output | 8 |
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3539_secretno.svg)

--- a/projects/tt3540.md
+++ b/projects/tt3540.md
@@ -1,0 +1,18 @@
+# My first Wokwi design
+
+**Source:** [https://github.com/PolykarposV/tt_workshop](https://github.com/PolykarposV/tt_workshop)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3540](https://app.tinytapeout.com/projects/3540)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| SWITCHES | input | 8 |
+| SEGMENTS | output | 8 |
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3540_wokwi.svg)

--- a/projects/tt3541.md
+++ b/projects/tt3541.md
@@ -1,0 +1,19 @@
+# tt3541-2bit-adder
+
+**Source:** [https://github.com/zeynepdemirdag/tiny-tapeout-submission](https://github.com/zeynepdemirdag/tiny-tapeout-submission)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3541](https://app.tinytapeout.com/projects/3541)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| A | input | 1 |
+| B | input | 1 |
+| Cin | input | 1 |
+| S | output | 1 |
+| Cout | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3541_2bit_adder.svg)

--- a/projects/tt3542.md
+++ b/projects/tt3542.md
@@ -1,0 +1,17 @@
+# VGABlock
+
+**Source:** [https://github.com/ezelioli/tt-efcl-workshop](https://github.com/ezelioli/tt-efcl-workshop)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3542](https://app.tinytapeout.com/projects/3542)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UO_OUT | output | 8 |
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3542_vgablock.svg)

--- a/projects/tt3543.md
+++ b/projects/tt3543.md
@@ -1,0 +1,23 @@
+# SotaSoC
+
+**Source:** [https://github.com/sotatek-dev/ttihp-SotaSoC](https://github.com/sotatek-dev/ttihp-SotaSoC)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3543](https://app.tinytapeout.com/projects/3543)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| SPI_MISO | input | 1 |
+| GPIO_IN | input | 6 |
+| UART0_RX | input | 1 |
+| UART0_TX | output | 1 |
+| ERROR_FLAG | output | 1 |
+| GPIO_OUT | output | 6 |
+| UIO | inout | 8 |
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3543_sotasoc.svg)

--- a/projects/tt3545.md
+++ b/projects/tt3545.md
@@ -1,0 +1,18 @@
+# Tiny Ape Out
+
+**Source:** [https://github.com/Byte-01100110/TT-Ape-out](https://github.com/Byte-01100110/TT-Ape-out)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3545](https://app.tinytapeout.com/projects/3545)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3545_apeout.svg)

--- a/projects/tt3546.md
+++ b/projects/tt3546.md
@@ -1,0 +1,16 @@
+# tt3546-counter
+
+**Source:** [https://github.com/mlhktp/ttihp-wokwi](https://github.com/mlhktp/ttihp-wokwi)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3546](https://app.tinytapeout.com/projects/3546)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3546_counter.svg)

--- a/projects/tt3547.md
+++ b/projects/tt3547.md
@@ -1,0 +1,22 @@
+# tiny-tapeout-workshop-result
+
+**Source:** [https://github.com/raninninn/tiny-tapeout-working-repo](https://github.com/raninninn/tiny-tapeout-working-repo)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3547](https://app.tinytapeout.com/projects/3547)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| INPUT_A | input | 1 |
+| INPUT_B | input | 1 |
+| ENABLE | input | 1 |
+| MUX_OUT | output | 1 |
+| COPY_A | output | 1 |
+| COPY_B | output | 1 |
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3547_workshop.svg)

--- a/projects/tt3548.md
+++ b/projects/tt3548.md
@@ -1,0 +1,19 @@
+# Full Adder Test
+
+**Source:** [https://github.com/joh-1x/tiny-tapeout-workshop](https://github.com/joh-1x/tiny-tapeout-workshop)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3548](https://app.tinytapeout.com/projects/3548)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| A | input | 1 |
+| B | input | 1 |
+| Cin | input | 1 |
+| Sum | output | 1 |
+| Cout | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3548_full_adder.svg)

--- a/projects/tt3549.md
+++ b/projects/tt3549.md
@@ -1,0 +1,18 @@
+# Tiny Triangle Rasterizer
+
+**Source:** [https://github.com/tomolt/tomolt_tiny_tapeout_ic](https://github.com/tomolt/tomolt_tiny_tapeout_ic)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3549](https://app.tinytapeout.com/projects/3549)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| rst_n | input | 1 |
+| hsync | output | 1 |
+| vsync | output | 1 |
+| RGB | output | 3 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3549_rasterizer.svg)

--- a/projects/tt3550.md
+++ b/projects/tt3550.md
@@ -1,0 +1,16 @@
+# (Hexa)Decimal Counter
+
+**Source:** [https://github.com/elFuchso/tinytapeout-wokwi](https://github.com/elFuchso/tinytapeout-wokwi)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3550](https://app.tinytapeout.com/projects/3550)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3550_counter.svg)

--- a/projects/tt3551.md
+++ b/projects/tt3551.md
@@ -1,0 +1,16 @@
+# Mein Hund Gniesbert (Adder for 3)
+
+**Source:** [https://github.com/sisarikaya/mytiny](https://github.com/sisarikaya/mytiny)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3551](https://app.tinytapeout.com/projects/3551)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3551_gniesbert.svg)

--- a/projects/tt3552.md
+++ b/projects/tt3552.md
@@ -1,0 +1,15 @@
+# Primitive clock divider
+
+**Source:** [https://github.com/alexey-serdyuk/tiny_tapeout_workshop](https://github.com/alexey-serdyuk/tiny_tapeout_workshop)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3552](https://app.tinytapeout.com/projects/3552)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3552_clk_div.svg)

--- a/projects/tt3553.md
+++ b/projects/tt3553.md
@@ -1,0 +1,16 @@
+# adder
+
+**Source:** [https://github.com/stsar/tiny_tapeout](https://github.com/stsar/tiny_tapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3553](https://app.tinytapeout.com/projects/3553)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3553_adder.svg)

--- a/projects/tt3554.md
+++ b/projects/tt3554.md
@@ -1,0 +1,16 @@
+# 7-Segment-Wokwi-Design
+
+**Source:** [https://github.com/MarvinBrth/7-Segment-Wokwi-Design](https://github.com/MarvinBrth/7-Segment-Wokwi-Design)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3554](https://app.tinytapeout.com/projects/3554)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 3 |
+| uo_out | output | 7 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3554_7seg_letter.svg)

--- a/projects/tt3555.md
+++ b/projects/tt3555.md
@@ -1,0 +1,16 @@
+# Second TT experiment
+
+**Source:** [https://github.com/fschh/tt-experiment](https://github.com/fschh/tt-experiment)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3555](https://app.tinytapeout.com/projects/3555)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3555_experiment.svg)

--- a/projects/tt3556.md
+++ b/projects/tt3556.md
@@ -1,0 +1,18 @@
+# Yturkeri_Mytinytapeout
+
+**Source:** [https://wokwi.com/projects/455293410637770753](https://wokwi.com/projects/455293410637770753)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3556](https://app.tinytapeout.com/projects/3556)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3556_yturkeri.svg)

--- a/projects/tt3557.md
+++ b/projects/tt3557.md
@@ -1,0 +1,19 @@
+# Clocked Full Adder
+
+**Source:** [https://github.com/tobiasgreiser/tiny_tapeout_workshop](https://github.com/tobiasgreiser/tiny_tapeout_workshop)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3557](https://app.tinytapeout.com/projects/3557)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| A | input | 1 |
+| B | input | 1 |
+| Cin | input | 1 |
+| S | output | 1 |
+| Cout | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3557_clocked_adder.svg)

--- a/projects/tt3558.md
+++ b/projects/tt3558.md
@@ -1,0 +1,16 @@
+# Cool Stuff
+
+**Source:** [https://github.com/PaxPlay/tiny-tapeout-design](https://github.com/PaxPlay/tiny-tapeout-design)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3558](https://app.tinytapeout.com/projects/3558)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3558_cool_stuff.svg)

--- a/projects/tt3559.md
+++ b/projects/tt3559.md
@@ -1,0 +1,16 @@
+# Just logic
+
+**Source:** [https://github.com/Jannis-Uni/TinyTapeout](https://github.com/Jannis-Uni/TinyTapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3559](https://app.tinytapeout.com/projects/3559)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3559_just_logic.svg)

--- a/projects/tt3560.md
+++ b/projects/tt3560.md
@@ -1,0 +1,18 @@
+# RGB PWM
+
+**Source:** [https://github.com/JohannesNekes/Tiny-Tapeout-RGB-PWM](https://github.com/JohannesNekes/Tiny-Tapeout-RGB-PWM)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3560](https://app.tinytapeout.com/projects/3560)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3560_rgb_pwm.svg)

--- a/projects/tt3561.md
+++ b/projects/tt3561.md
@@ -1,0 +1,19 @@
+# uCore
+
+**Source:** [https://github.com/yJulian/tiny-tapeout](https://github.com/yJulian/tiny-tapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3561](https://app.tinytapeout.com/projects/3561)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| rst_n | input | 1 |
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3561_ucore.svg)

--- a/projects/tt3562.md
+++ b/projects/tt3562.md
@@ -1,0 +1,17 @@
+# 7-Segment Adder (0, 1, 2)
+
+**Source:** [https://github.com/Ancash/tt](https://github.com/Ancash/tt)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3562](https://app.tinytapeout.com/projects/3562)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0] | input | 1 |
+| ui[1] | input | 1 |
+| uo[0:6] | output | 7 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3562_title.svg)

--- a/projects/tt3563.md
+++ b/projects/tt3563.md
@@ -1,0 +1,18 @@
+# RS Half adder
+
+**Source:** [https://github.com/yNiklas/tt-chip-design](https://github.com/yNiklas/tt-chip-design)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3563](https://app.tinytapeout.com/projects/3563)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3563_rs_half_adder.svg)

--- a/projects/tt3564.md
+++ b/projects/tt3564.md
@@ -1,0 +1,16 @@
+# tt3564-2bit-adder
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3564](https://app.tinytapeout.com/projects/3564)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| A | input | 2 |
+| B | input | 2 |
+| Result | output | 2 |
+| Cout | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3564_2bit_adder.svg)

--- a/projects/tt3565.md
+++ b/projects/tt3565.md
@@ -1,0 +1,18 @@
+# FH Joanneum TinyTapeout
+
+**Source:** [https://github.com/leo0111001/TTIHP26a-FH-Joanneum](https://github.com/leo0111001/TTIHP26a-FH-Joanneum)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3565](https://app.tinytapeout.com/projects/3565)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3565_soc.svg)

--- a/projects/tt3566.md
+++ b/projects/tt3566.md
@@ -1,0 +1,17 @@
+# test (AND gate)
+
+**Source:** [https://github.com/DasKunstUngetuem/tt](https://github.com/DasKunstUngetuem/tt)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3566](https://app.tinytapeout.com/projects/3566)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3566_test.svg)

--- a/projects/tt3567.md
+++ b/projects/tt3567.md
@@ -1,0 +1,18 @@
+# Inverter Template Test
+
+**Source:** [https://github.com/trupus/tt](https://github.com/trupus/tt)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3567](https://app.tinytapeout.com/projects/3567)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0:3] | input | 4 |
+| ui[4:7] | input | 4 |
+| uo[0:3] | output | 4 |
+| uo[4:7] | output | 4 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3567_test.svg)

--- a/projects/tt3568.md
+++ b/projects/tt3568.md
@@ -1,0 +1,16 @@
+# My first tapeout
+
+**Source:** [https://github.com/youju26/tinytapeout](https://github.com/youju26/tinytapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3568](https://app.tinytapeout.com/projects/3568)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3568_my_first_tapeout.svg)

--- a/projects/tt3569.md
+++ b/projects/tt3569.md
@@ -1,0 +1,19 @@
+# RTX 8090
+
+**Source:** [https://github.com/agentzz1/GDS_tinytapeout](https://github.com/agentzz1/GDS_tinytapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3569](https://app.tinytapeout.com/projects/3569)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| uio_out | output | 8 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3569_rtx8090.svg)

--- a/projects/tt3570.md
+++ b/projects/tt3570.md
@@ -1,0 +1,18 @@
+# Temporary Title
+
+**Source:** [https://github.com/IsAreWhoKey/TTWorkshopThing](https://github.com/IsAreWhoKey/TTWorkshopThing)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3570](https://app.tinytapeout.com/projects/3570)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3570_temp_title.svg)

--- a/projects/tt3571.md
+++ b/projects/tt3571.md
@@ -1,0 +1,17 @@
+# Tiny Tapeout N
+
+**Source:** [https://github.com/Nama222/Tiny-Tapeout](https://github.com/Nama222/Tiny-Tapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3571](https://app.tinytapeout.com/projects/3571)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3571_toso.svg)

--- a/projects/tt3572.md
+++ b/projects/tt3572.md
@@ -1,0 +1,18 @@
+# Tiny Tapeout - Riddle Implementation
+
+**Source:** [https://github.com/Aber-58/TinyTapeout-Aber](https://github.com/Aber-58/TinyTapeout-Aber)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3572](https://app.tinytapeout.com/projects/3572)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0:3] | input | 4 |
+| ui[4:7] | input | 4 |
+| uo[0:3] | output | 4 |
+| uo[4:7] | output | 4 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3572_riddle.svg)

--- a/projects/tt3573.md
+++ b/projects/tt3573.md
@@ -1,0 +1,16 @@
+# Custom_ASIC
+
+**Source:** [https://github.com/jackb7273-jpg/Tiny_Tapeout](https://github.com/jackb7273-jpg/Tiny_Tapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3573](https://app.tinytapeout.com/projects/3573)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3573_custom_asic.svg)

--- a/projects/tt3574.md
+++ b/projects/tt3574.md
@@ -1,0 +1,16 @@
+# Tudor BCD Test
+
+**Source:** [https://github.com/Tuda05/TinyTapeout](https://github.com/Tuda05/TinyTapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3574](https://app.tinytapeout.com/projects/3574)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3574_bcd.svg)

--- a/projects/tt3575.md
+++ b/projects/tt3575.md
@@ -1,0 +1,18 @@
+# FirstTapeOut2
+
+**Source:** [https://github.com/pageeecs/FirstTapeout](https://github.com/pageeecs/FirstTapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3575](https://app.tinytapeout.com/projects/3575)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3575_red_and.svg)

--- a/projects/tt3576.md
+++ b/projects/tt3576.md
@@ -1,0 +1,16 @@
+# Tiny Tapeout Test
+
+**Source:** [https://github.com/MertErmann/tiny_tapeout_1](https://github.com/MertErmann/tiny_tapeout_1)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3576](https://app.tinytapeout.com/projects/3576)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3576_test.svg)

--- a/projects/tt3577.md
+++ b/projects/tt3577.md
@@ -1,0 +1,16 @@
+# 18-bit Ripple Counter
+
+**Source:** [https://github.com/by-Tobd/tinytapeout](https://github.com/by-Tobd/tinytapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3577](https://app.tinytapeout.com/projects/3577)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3577_counter.svg)

--- a/projects/tt3578.md
+++ b/projects/tt3578.md
@@ -1,0 +1,16 @@
+# neb tt26a first asic
+
+**Source:** [https://github.com/neb-o/tinytapeout_260207](https://github.com/neb-o/tinytapeout_260207)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3578](https://app.tinytapeout.com/projects/3578)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3578_neb_tt26a_first_asic.svg)

--- a/projects/tt3579.md
+++ b/projects/tt3579.md
@@ -1,0 +1,18 @@
+# Programmable 8-BIT CPU
+
+**Source:** [https://github.com/dranoel06/tiny_tapeout_dranoel06](https://github.com/dranoel06/tiny_tapeout_dranoel06)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3579](https://app.tinytapeout.com/projects/3579)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3579_cpu.svg)

--- a/projects/tt3580.md
+++ b/projects/tt3580.md
@@ -1,0 +1,18 @@
+# Try1
+
+**Source:** [https://github.com/ManaOverflow/TinyTapeoutWorkshop](https://github.com/ManaOverflow/TinyTapeoutWorkshop)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3580](https://app.tinytapeout.com/projects/3580)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3580_try1.svg)

--- a/projects/tt3581.md
+++ b/projects/tt3581.md
@@ -1,0 +1,16 @@
+# random stuff (NOT gates)
+
+**Source:** [https://github.com/vlad-penchev/tinytapeoutz](https://github.com/vlad-penchev/tinytapeoutz)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3581](https://app.tinytapeout.com/projects/3581)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3581_random.svg)

--- a/projects/tt3582.md
+++ b/projects/tt3582.md
@@ -1,0 +1,18 @@
+# Invertors Class Template
+
+**Source:** [https://github.com/Shanmukha-ms/cim_tiny_tapeout](https://github.com/Shanmukha-ms/cim_tiny_tapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3582](https://app.tinytapeout.com/projects/3582)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0:3] | input | 4 |
+| ui[4:7] | input | 4 |
+| uo[0:3] | output | 4 |
+| uo[4:7] | output | 4 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3582_invertors.svg)

--- a/projects/tt3584.md
+++ b/projects/tt3584.md
@@ -1,0 +1,16 @@
+# Tiny Tapeout
+
+**Source:** [https://github.com/Tuan9304/gds](https://github.com/Tuan9304/gds)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3584](https://app.tinytapeout.com/projects/3584)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3584_test.svg)

--- a/projects/tt3585.md
+++ b/projects/tt3585.md
@@ -1,0 +1,18 @@
+# Tiny Tapeout
+
+**Source:** [https://github.com/AriVishnu-01/Tiny-Tapeout](https://github.com/AriVishnu-01/Tiny-Tapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3585](https://app.tinytapeout.com/projects/3585)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3585_or_gates.svg)

--- a/projects/tt3586.md
+++ b/projects/tt3586.md
@@ -1,0 +1,18 @@
+# Clock Divider Test Project
+
+**Source:** [https://github.com/werrever/TinyTapeout_werrever](https://github.com/werrever/TinyTapeout_werrever)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3586](https://app.tinytapeout.com/projects/3586)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3586_clk_div.svg)

--- a/projects/tt3587.md
+++ b/projects/tt3587.md
@@ -1,0 +1,18 @@
+# lriglooCs-first-Wokwi-design
+
+**Source:** [https://wokwi.com/projects/455291649222749185](https://wokwi.com/projects/455291649222749185)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3587](https://app.tinytapeout.com/projects/3587)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3587_lriglooc.svg)

--- a/projects/tt3588.md
+++ b/projects/tt3588.md
@@ -1,0 +1,17 @@
+# custom_lol
+
+**Source:** [https://github.com/mar-3123/tiny_tapeout](https://github.com/mar-3123/tiny_tapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3588](https://app.tinytapeout.com/projects/3588)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3588_custom_lol.svg)

--- a/projects/tt3589.md
+++ b/projects/tt3589.md
@@ -1,0 +1,16 @@
+# 83rk: Tiny Tapeout
+
+**Source:** [https://github.com/83rk/83rkFlipFlop](https://github.com/83rk/83rkFlipFlop)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3589](https://app.tinytapeout.com/projects/3589)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3589_sr_ff.svg)

--- a/projects/tt3590.md
+++ b/projects/tt3590.md
@@ -1,0 +1,19 @@
+# bad multiplexer
+
+**Source:** [https://github.com/jknotrowling/TinyTapeout](https://github.com/jknotrowling/TinyTapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3590](https://app.tinytapeout.com/projects/3590)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3590_bad_mux.svg)

--- a/projects/tt3591.md
+++ b/projects/tt3591.md
@@ -1,0 +1,18 @@
+# Tiny Tapeout N
+
+**Source:** [https://github.com/Nama222/Tiny-Tapeout](https://github.com/Nama222/Tiny-Tapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3591](https://app.tinytapeout.com/projects/3591)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3591.svg)

--- a/projects/tt3592.md
+++ b/projects/tt3592.md
@@ -1,0 +1,18 @@
+# 4-to-1 Multiplexer
+
+**Source:** [https://github.com/kenny3010/GDS1](https://github.com/kenny3010/GDS1)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3592](https://app.tinytapeout.com/projects/3592)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0:3] | input | 4 |
+| ui[5] | input | 1 |
+| ui[6] | input | 1 |
+| uo[0] | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3592_test.svg)

--- a/projects/tt3593.md
+++ b/projects/tt3593.md
@@ -1,0 +1,16 @@
+# Workshop Day
+
+**Source:** [https://github.com/Montagsfrei/TinyTapeoutWorkshop](https://github.com/Montagsfrei/TinyTapeoutWorkshop)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3593](https://app.tinytapeout.com/projects/3593)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3593_workshop_day.svg)

--- a/projects/tt3594.md
+++ b/projects/tt3594.md
@@ -1,0 +1,16 @@
+# Test
+
+**Source:** [https://github.com/darius1702/tt-asic](https://github.com/darius1702/tt-asic)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3594](https://app.tinytapeout.com/projects/3594)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3594_test.svg)

--- a/projects/tt3595.md
+++ b/projects/tt3595.md
@@ -1,0 +1,18 @@
+# Hello tinyTapout
+
+**Source:** [https://github.com/SinnMachen/nein](https://github.com/SinnMachen/nein)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3595](https://app.tinytapeout.com/projects/3595)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3595_hello_tt.svg)

--- a/projects/tt3596.md
+++ b/projects/tt3596.md
@@ -1,0 +1,16 @@
+# TinyTapeoutTestProject
+
+**Source:** [https://github.com/agentofail/TinyTapeout](https://github.com/agentofail/TinyTapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3596](https://app.tinytapeout.com/projects/3596)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3596.svg)

--- a/projects/tt3597.md
+++ b/projects/tt3597.md
@@ -1,0 +1,16 @@
+# Apfelstrudel
+
+**Source:** [https://github.com/Nampuk/tapatapatapa](https://github.com/Nampuk/tapatapatapa)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3597](https://app.tinytapeout.com/projects/3597)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0:7] | input | 8 |
+| uo[0:7] | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3597_apfelstrudel.svg)

--- a/projects/tt3598.md
+++ b/projects/tt3598.md
@@ -1,0 +1,16 @@
+# Freddys tapeout
+
+**Source:** [https://github.com/Freddy-mllr/FreddysTapeout](https://github.com/Freddy-mllr/FreddysTapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3598](https://app.tinytapeout.com/projects/3598)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3598_freddys_tapeout.svg)

--- a/projects/tt3599.md
+++ b/projects/tt3599.md
@@ -1,0 +1,16 @@
+# ^My first design
+
+**Source:** [https://github.com/mabo-elfotoh/my_tiny_tape_design](https://github.com/mabo-elfotoh/my_tiny_tape_design)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3599](https://app.tinytapeout.com/projects/3599)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3599_first_design.svg)

--- a/projects/tt3600.md
+++ b/projects/tt3600.md
@@ -1,0 +1,18 @@
+# Simon Says
+
+**Source:** [https://github.com/dabro02/Daniel-s-Wokwi-Design](https://github.com/dabro02/Daniel-s-Wokwi-Design)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3600](https://app.tinytapeout.com/projects/3600)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3600_serializer.svg)

--- a/projects/tt3601.md
+++ b/projects/tt3601.md
@@ -1,0 +1,16 @@
+# just copy 4 not gates
+
+**Source:** [https://github.com/RussLi-IDK/Create-the-GDS](https://github.com/RussLi-IDK/Create-the-GDS)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3601](https://app.tinytapeout.com/projects/3601)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3601.svg)

--- a/projects/tt3602.md
+++ b/projects/tt3602.md
@@ -1,0 +1,20 @@
+# Flip-Flop Test
+
+**Source:** [https://github.com/PleinR02/test](https://github.com/PleinR02/test)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3602](https://app.tinytapeout.com/projects/3602)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[2] | input | 1 |
+| ui[3] | input | 1 |
+| ui[4] | input | 1 |
+| ui[6] | input | 1 |
+| uo[3] | output | 1 |
+| uo[7] | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3602_test.svg)

--- a/projects/tt3603.md
+++ b/projects/tt3603.md
@@ -1,0 +1,18 @@
+# TinyTapeout logic gate test
+
+**Source:** [https://wokwi.com/projects/455291787137823745](https://wokwi.com/projects/455291787137823745)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3603](https://app.tinytapeout.com/projects/3603)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3603_gates.svg)

--- a/projects/tt3604.md
+++ b/projects/tt3604.md
@@ -1,0 +1,16 @@
+# Tobias first Wokwi design
+
+**Source:** [https://github.com/ucmpb/TinyTapeout](https://github.com/ucmpb/TinyTapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3604](https://app.tinytapeout.com/projects/3604)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3604_tobias.svg)

--- a/projects/tt3605.md
+++ b/projects/tt3605.md
@@ -1,0 +1,18 @@
+# DDMTD
+
+**Source:** [https://github.com/ArthFink/TinyTapeout](https://github.com/ArthFink/TinyTapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3605](https://app.tinytapeout.com/projects/3605)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3605_ddmtd.svg)

--- a/projects/tt3606.md
+++ b/projects/tt3606.md
@@ -1,0 +1,16 @@
+# Tiny Tapeout Accumulator
+
+**Source:** [https://github.com/alpblkba/tiny-tapeout-chip-design](https://github.com/alpblkba/tiny-tapeout-chip-design)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3606](https://app.tinytapeout.com/projects/3606)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3606.svg)

--- a/projects/tt3607.md
+++ b/projects/tt3607.md
@@ -1,0 +1,20 @@
+# Switch Puzzle Logic
+
+**Source:** [https://github.com/RimaitosLab/TinyTapeoutWorkshop](https://github.com/RimaitosLab/TinyTapeoutWorkshop)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3607](https://app.tinytapeout.com/projects/3607)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0] | input | 1 |
+| ui[1] | input | 1 |
+| ui[4:7] | input | 4 |
+| uo[0] | output | 1 |
+| uo[1] | output | 1 |
+| uo[4:7] | output | 4 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3607_puzzle.svg)

--- a/projects/tt3608.md
+++ b/projects/tt3608.md
@@ -1,0 +1,19 @@
+# Full Adder (Doom?)
+
+**Source:** [https://github.com/TobisMa/GDS](https://github.com/TobisMa/GDS)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3608](https://app.tinytapeout.com/projects/3608)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| A | input | 1 |
+| B | input | 1 |
+| Cin | input | 1 |
+| Sum | output | 1 |
+| Cout | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3608_full_adder.svg)

--- a/projects/tt3609.md
+++ b/projects/tt3609.md
@@ -1,0 +1,18 @@
+# tinytapeout
+
+**Source:** [https://wokwi.com/projects/455291692116877313](https://wokwi.com/projects/455291692116877313)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3609](https://app.tinytapeout.com/projects/3609)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3609_tinytapeout.svg)

--- a/projects/tt3610.md
+++ b/projects/tt3610.md
@@ -1,0 +1,18 @@
+# Test
+
+**Source:** [https://github.com/LordTaek/GDS_Creator](https://github.com/LordTaek/GDS_Creator)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3610](https://app.tinytapeout.com/projects/3610)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3610_test.svg)

--- a/projects/tt3611.md
+++ b/projects/tt3611.md
@@ -1,0 +1,17 @@
+# Count Upwards (7-segment)
+
+**Source:** [https://github.com/Andreas-Noebel/Tiny-Tapeout](https://github.com/Andreas-Noebel/Tiny-Tapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3611](https://app.tinytapeout.com/projects/3611)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3611_counter.svg)

--- a/projects/tt3612.md
+++ b/projects/tt3612.md
@@ -1,0 +1,16 @@
+# 6-bit Ring Register
+
+**Source:** [https://github.com/flo100500/tinytapeout](https://github.com/flo100500/tinytapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3612](https://app.tinytapeout.com/projects/3612)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| uo[0:5] | output | 6 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3612_shift.svg)

--- a/projects/tt3613.md
+++ b/projects/tt3613.md
@@ -1,0 +1,17 @@
+# Nielss first failure
+
+**Source:** [https://github.com/Engelbrecht-N/Wokiwi_template](https://github.com/Engelbrecht-N/Wokiwi_template)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3613](https://app.tinytapeout.com/projects/3613)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3613_nielss_first_failure.svg)

--- a/projects/tt3614.md
+++ b/projects/tt3614.md
@@ -1,0 +1,16 @@
+# 1-bit Full Adder
+
+**Source:** [https://github.com/nusli7/TT-Project](https://github.com/nusli7/TT-Project)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3614](https://app.tinytapeout.com/projects/3614)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3614_full_adder.svg)

--- a/projects/tt3615.md
+++ b/projects/tt3615.md
@@ -1,0 +1,17 @@
+# gatekeeping the gates
+
+**Source:** [https://github.com/Geronymos/tinytapeout](https://github.com/Geronymos/tinytapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3615](https://app.tinytapeout.com/projects/3615)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3615_gates.svg)

--- a/projects/tt3616.md
+++ b/projects/tt3616.md
@@ -1,0 +1,18 @@
+# Two Song Buzzer Player
+
+**Source:** [https://github.com/CT4111/test_WOKWI_Circute](https://github.com/CT4111/test_WOKWI_Circute)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3616](https://app.tinytapeout.com/projects/3616)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3616_buzzer.svg)

--- a/projects/tt3617.md
+++ b/projects/tt3617.md
@@ -1,0 +1,16 @@
+# 6-bit Ring Register WIP
+
+**Source:** [https://github.com/plhrtr/TinyTapeOutTest](https://github.com/plhrtr/TinyTapeOutTest)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3617](https://app.tinytapeout.com/projects/3617)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| uo[0:5] | output | 6 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3617_wip.svg)

--- a/projects/tt3618.md
+++ b/projects/tt3618.md
@@ -1,0 +1,19 @@
+# tt-verilog
+
+**Source:** [https://github.com/BenediktKeppner/tt-verilog](https://github.com/BenediktKeppner/tt-verilog)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3618](https://app.tinytapeout.com/projects/3618)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3618_verilog.svg)

--- a/projects/tt3619.md
+++ b/projects/tt3619.md
@@ -1,0 +1,16 @@
+# Tiny_Tapeout_Test
+
+**Source:** [https://github.com/Shaip161/TinyTapeOut](https://github.com/Shaip161/TinyTapeOut)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3619](https://app.tinytapeout.com/projects/3619)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3619_test.svg)

--- a/projects/tt3620.md
+++ b/projects/tt3620.md
@@ -1,0 +1,17 @@
+# Test
+
+**Source:** [https://github.com/can-lehmann/tt-fpga](https://github.com/can-lehmann/tt-fpga)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3620](https://app.tinytapeout.com/projects/3620)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3620_test.svg)

--- a/projects/tt3622.md
+++ b/projects/tt3622.md
@@ -1,0 +1,17 @@
+# WIP 7-seg Spinner
+
+**Source:** [https://github.com/DebuggingDisaster/wowki](https://github.com/DebuggingDisaster/wowki)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3622](https://app.tinytapeout.com/projects/3622)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| ui[0:7] | input | 8 |
+| uo[0:7] | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3622_wip.svg)

--- a/projects/tt3623.md
+++ b/projects/tt3623.md
@@ -1,0 +1,17 @@
+# little frequency divider
+
+**Source:** [https://github.com/pauld0503/paul_tiny_tapeout](https://github.com/pauld0503/paul_tiny_tapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3623](https://app.tinytapeout.com/projects/3623)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3623_freq_divider.svg)

--- a/projects/tt3624.md
+++ b/projects/tt3624.md
@@ -1,0 +1,17 @@
+# Tiny Tapeout 1
+
+**Source:** [https://github.com/makrs11/TinyTapeout-1](https://github.com/makrs11/TinyTapeout-1)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3624](https://app.tinytapeout.com/projects/3624)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3624_nn_test.svg)

--- a/projects/tt3625.md
+++ b/projects/tt3625.md
@@ -1,0 +1,16 @@
+# 74LS138 (Inverter + Pass-through)
+
+**Source:** [https://github.com/terrywtr/Tianrui-Wang](https://github.com/terrywtr/Tianrui-Wang)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3625](https://app.tinytapeout.com/projects/3625)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3625_74ls138.svg)

--- a/projects/tt3626.md
+++ b/projects/tt3626.md
@@ -1,0 +1,18 @@
+# Test - shift register
+
+**Source:** [https://github.com/sam-m7/tinyTapeoutChip1](https://github.com/sam-m7/tinyTapeoutChip1)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3626](https://app.tinytapeout.com/projects/3626)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3626_shift_reg.svg)

--- a/projects/tt3627.md
+++ b/projects/tt3627.md
@@ -1,0 +1,16 @@
+# DR Flip-flop Counter
+
+**Source:** [https://github.com/Estel64/Beccas_tinytapeout](https://github.com/Estel64/Beccas_tinytapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3627](https://app.tinytapeout.com/projects/3627)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| uo[0:3] | output | 4 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3627_counter.svg)

--- a/projects/tt3629.md
+++ b/projects/tt3629.md
@@ -1,0 +1,18 @@
+# WIP (Logic & Pass-through)
+
+**Source:** [https://github.com/kmosta19/TinyTapeoutProject](https://github.com/kmosta19/TinyTapeoutProject)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3629](https://app.tinytapeout.com/projects/3629)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3629_wip.svg)

--- a/projects/tt3630.md
+++ b/projects/tt3630.md
@@ -1,0 +1,17 @@
+# VGA demo
+
+**Source:** [https://github.com/mattvenn/ihp26a-vga-test](https://github.com/mattvenn/ihp26a-vga-test)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3630](https://app.tinytapeout.com/projects/3630)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3630_vga.svg)

--- a/projects/tt3632.md
+++ b/projects/tt3632.md
@@ -1,0 +1,21 @@
+# VGA Squares
+
+**Source:** [https://github.com/matth-fischer/TT_VGA](https://github.com/matth-fischer/TT_VGA)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3632](https://app.tinytapeout.com/projects/3632)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| ui[0] | input | 1 |
+| ui[1] | input | 1 |
+| uo[0:2] | output | 3 |
+| uo[3] | output | 1 |
+| uo[4:6] | output | 3 |
+| uo[7] | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3632_vga_squares.svg)

--- a/projects/tt3633.md
+++ b/projects/tt3633.md
@@ -1,0 +1,16 @@
+# VGA Maze Runner
+
+**Source:** [https://github.com/phsauter/vga-playground-maze](https://github.com/phsauter/vga-playground-maze)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3633](https://app.tinytapeout.com/projects/3633)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3633_vga_maze_runner.svg)

--- a/projects/tt3635.md
+++ b/projects/tt3635.md
@@ -1,0 +1,19 @@
+# TT6581
+
+**Source:** [https://github.com/apedersen00/tt6581](https://github.com/apedersen00/tt6581)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3635](https://app.tinytapeout.com/projects/3635)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3635_tt6581.svg)

--- a/projects/tt3638.md
+++ b/projects/tt3638.md
@@ -1,0 +1,18 @@
+# Yet another VGA tinytapeout
+
+**Source:** [https://github.com/zouzias/ttihp-verilog-eth](https://github.com/zouzias/ttihp-verilog-eth)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3638](https://app.tinytapeout.com/projects/3638)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3638_vga.svg)

--- a/projects/tt3640.md
+++ b/projects/tt3640.md
@@ -1,0 +1,17 @@
+# VGA Rings
+
+**Source:** [https://github.com/urish/tt-rings](https://github.com/urish/tt-rings)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3640](https://app.tinytapeout.com/projects/3640)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3640_vga_rings.svg)

--- a/projects/tt3641.md
+++ b/projects/tt3641.md
@@ -1,0 +1,20 @@
+# M31 Mersenne-31 Arithmetic Accelerator
+
+**Source:** [https://github.com/brmurrell3/tt_um_brmurrell3_m31_accel](https://github.com/brmurrell3/tt_um_brmurrell3_m31_accel)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3641](https://app.tinytapeout.com/projects/3641)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| uio_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3641_m31_accel.svg)

--- a/projects/tt3642.md
+++ b/projects/tt3642.md
@@ -1,0 +1,23 @@
+# Bit-Serial Collatz Checker
+
+**Source:** [https://github.com/TheMightyDuckOfDoom/tinytapeout-bit-serial-collatz](https://github.com/TheMightyDuckOfDoom/tinytapeout-bit-serial-collatz)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3642](https://app.tinytapeout.com/projects/3642)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| ui[0] | input | 1 |
+| ui[1] | input | 1 |
+| ui[2] | input | 1 |
+| ui[3] | input | 1 |
+| uo[0] | output | 1 |
+| uo[1] | output | 1 |
+| uo[2] | output | 1 |
+| uo[3] | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3642_collatz.svg)

--- a/projects/tt3645.md
+++ b/projects/tt3645.md
@@ -1,0 +1,19 @@
+# Borg - Vertex shader
+
+**Source:** [https://github.com/gonsolo/borg_tinyqv](https://github.com/gonsolo/borg_tinyqv)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3645](https://app.tinytapeout.com/projects/3645)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3645_borg.svg)

--- a/projects/tt3646.md
+++ b/projects/tt3646.md
@@ -1,0 +1,16 @@
+# 4-bit Counter
+
+**Source:** [https://github.com/Galayuda/tt-counter](https://github.com/Galayuda/tt-counter)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3646](https://app.tinytapeout.com/projects/3646)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3646_counter.svg)

--- a/projects/tt3647.md
+++ b/projects/tt3647.md
@@ -1,0 +1,18 @@
+# 2x2 Systolic Array
+
+**Source:** [https://github.com/Essenceia/Systolic_Array_with_DFT_v2](https://github.com/Essenceia/Systolic_Array_with_DFT_v2)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3647](https://app.tinytapeout.com/projects/3647)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO_IN | input | 8 |
+| UIO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3647_systolic.svg)

--- a/projects/tt3648.md
+++ b/projects/tt3648.md
@@ -1,0 +1,17 @@
+# tophat
+
+**Source:** [https://github.com/pgfarley/tophat](https://github.com/pgfarley/tophat)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3648](https://app.tinytapeout.com/projects/3648)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3648_tophat.svg)

--- a/projects/tt3650.md
+++ b/projects/tt3650.md
@@ -1,0 +1,17 @@
+# Cyber EMBEDDEDINN
+
+**Source:** [https://github.com/vppillai/tt-vga-submission](https://github.com/vppillai/tt-vga-submission)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3650](https://app.tinytapeout.com/projects/3650)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3650_vga_cyber.svg)

--- a/projects/tt3651.md
+++ b/projects/tt3651.md
@@ -1,0 +1,18 @@
+# Silly demo
+
+**Source:** [https://github.com/BoredSemiRetiredEngineer/ttihp_submission](https://github.com/BoredSemiRetiredEngineer/ttihp_submission)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3651](https://app.tinytapeout.com/projects/3651)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3651_silly_demo.svg)

--- a/projects/tt3653.md
+++ b/projects/tt3653.md
@@ -1,0 +1,17 @@
+# SID Voice Synthesizer
+
+**Source:** [https://github.com/rrrh/tiny_sid_chip](https://github.com/rrrh/tiny_sid_chip)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3653](https://app.tinytapeout.com/projects/3653)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3653_sid_voice_synthesizer.svg)

--- a/projects/tt3654.md
+++ b/projects/tt3654.md
@@ -1,0 +1,18 @@
+# TinyMOA: RISC-V CPU with CIM Accelerator
+
+**Source:** [https://github.com/EzraWolf/TinyMOA-IHP26a](https://github.com/EzraWolf/TinyMOA-IHP26a)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3654](https://app.tinytapeout.com/projects/3654)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3654_tinymoa.svg)

--- a/projects/tt3656.md
+++ b/projects/tt3656.md
@@ -1,0 +1,16 @@
+# Chisel Async Test
+
+**Source:** [https://github.com/tjarker/ttihp-feb-2026](https://github.com/tjarker/ttihp-feb-2026)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3656](https://app.tinytapeout.com/projects/3656)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3656.svg)

--- a/projects/tt3657.md
+++ b/projects/tt3657.md
@@ -1,0 +1,17 @@
+# tt3657-4bit-adder
+
+**Source:** [https://github.com/madsamtoft/TinyTapeout2](https://github.com/madsamtoft/TinyTapeout2)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3657](https://app.tinytapeout.com/projects/3657)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| A | input | 4 |
+| B | input | 4 |
+| Sum | output | 5 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3657_4bit_adder.svg)

--- a/projects/tt3659.md
+++ b/projects/tt3659.md
@@ -1,0 +1,19 @@
+# quad-sieve
+
+**Source:** [https://github.com/swenson/ttihp-quad-sieve](https://github.com/swenson/ttihp-quad-sieve)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3659](https://app.tinytapeout.com/projects/3659)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3659_quad_sieve.svg)

--- a/projects/tt3661.md
+++ b/projects/tt3661.md
@@ -1,0 +1,17 @@
+# LLR simple VGA GPU
+
+**Source:** [https://github.com/leonllrmc/tinytapeout_26a_llrsub1](https://github.com/leonllrmc/tinytapeout_26a_llrsub1)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3661](https://app.tinytapeout.com/projects/3661)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3661_vga_gpu.svg)

--- a/projects/tt3662.md
+++ b/projects/tt3662.md
@@ -1,0 +1,18 @@
+# ttip-test
+
+**Source:** [https://github.com/YashKarthik/ttihp-counter](https://github.com/YashKarthik/ttihp-counter)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3662](https://app.tinytapeout.com/projects/3662)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3662_test.svg)

--- a/projects/tt3663.md
+++ b/projects/tt3663.md
@@ -1,0 +1,18 @@
+# Johnson counter
+
+**Source:** [https://github.com/EhsanKhodadad/ttihp-wokwi](https://github.com/EhsanKhodadad/ttihp-wokwi)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3663](https://app.tinytapeout.com/projects/3663)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3663_johnson_counter.svg)

--- a/projects/tt3664.md
+++ b/projects/tt3664.md
@@ -1,0 +1,18 @@
+# Glitcher (Pulse Generator)
+
+**Source:** [https://github.com/pakesson/tt_glitcher](https://github.com/pakesson/tt_glitcher)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3664](https://app.tinytapeout.com/projects/3664)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3664_glitcher.svg)

--- a/projects/tt3665.md
+++ b/projects/tt3665.md
@@ -1,0 +1,17 @@
+# TeenySPU
+
+**Source:** [https://github.com/umn-geocommons/tt_um_teenyspu](https://github.com/umn-geocommons/tt_um_teenyspu)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3665](https://app.tinytapeout.com/projects/3665)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO_IN | input | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3665_teenyspu.svg)

--- a/projects/tt3666.md
+++ b/projects/tt3666.md
@@ -1,0 +1,18 @@
+# Moving Average Filter
+
+**Source:** [https://github.com/jonathan-farah/Sensors_and_Security](https://github.com/jonathan-farah/Sensors_and_Security)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3666](https://app.tinytapeout.com/projects/3666)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO_IN | input | 6 |
+| UIO_OUT | output | 2 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3666_dsp.svg)

--- a/projects/tt3667.md
+++ b/projects/tt3667.md
@@ -1,0 +1,17 @@
+# 8Bit Posit MAC Unit
+
+**Source:** [https://github.com/RipunjayS109/posit_mac](https://github.com/RipunjayS109/posit_mac)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3667](https://app.tinytapeout.com/projects/3667)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| ui[0:7] | input | 8 |
+| uo[0:7] | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3667_posit_mac.svg)

--- a/projects/tt3668.md
+++ b/projects/tt3668.md
@@ -1,0 +1,16 @@
+# Tiny tapeout and gate test
+
+**Source:** [https://github.com/kessler-christopher/tt_chris_test](https://github.com/kessler-christopher/tt_chris_test)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3668](https://app.tinytapeout.com/projects/3668)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3668_and_gate.svg)

--- a/projects/tt3669.md
+++ b/projects/tt3669.md
@@ -1,0 +1,19 @@
+# Tiny Perceptron (Branch Predictor)
+
+**Source:** [https://github.com/karlmose/tinytapeout_wokwi_test](https://github.com/karlmose/tinytapeout_wokwi_test)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3669](https://app.tinytapeout.com/projects/3669)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3669_tiny_perceptron.svg)

--- a/projects/tt3670.md
+++ b/projects/tt3670.md
@@ -1,0 +1,17 @@
+# Full Adder
+
+**Source:** [https://github.com/AAmirinejad/TinyTapeoutWorkshop](https://github.com/AAmirinejad/TinyTapeoutWorkshop)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3670](https://app.tinytapeout.com/projects/3670)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3670_full_adder.svg)

--- a/projects/tt3671.md
+++ b/projects/tt3671.md
@@ -1,0 +1,17 @@
+# Test (AND gate)
+
+**Source:** [https://github.com/Biboulder/TinyTapeout-wokwi-template](https://github.com/Biboulder/TinyTapeout-wokwi-template)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3671](https://app.tinytapeout.com/projects/3671)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3671_test.svg)

--- a/projects/tt3674.md
+++ b/projects/tt3674.md
@@ -1,0 +1,16 @@
+# tt3674-7seg-binary
+
+**Source:** [https://github.com/jonbng/tinytapeout-binary-to-7segment](https://github.com/jonbng/tinytapeout-binary-to-7segment)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3674](https://app.tinytapeout.com/projects/3674)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3674_7seg_binary.svg)

--- a/projects/tt3675.md
+++ b/projects/tt3675.md
@@ -1,0 +1,19 @@
+# SPI and I2C Register Bank
+
+**Source:** [https://github.com/calonso88/dtu_tt_workshop](https://github.com/calonso88/dtu_tt_workshop)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3675](https://app.tinytapeout.com/projects/3675)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3675_reg_bank.svg)

--- a/projects/tt3676.md
+++ b/projects/tt3676.md
@@ -1,0 +1,17 @@
+# Counter Circuit
+
+**Source:** [https://github.com/Mr-Seoul/TinyTapeOutGDS](https://github.com/Mr-Seoul/TinyTapeOutGDS)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3676](https://app.tinytapeout.com/projects/3676)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3676_counter.svg)

--- a/projects/tt3678.md
+++ b/projects/tt3678.md
@@ -1,0 +1,16 @@
+# 2 Digit Display
+
+**Source:** [https://github.com/MathiasKES/TinyTapeout2026-wokwi](https://github.com/MathiasKES/TinyTapeout2026-wokwi)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3678](https://app.tinytapeout.com/projects/3678)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3678_2_digit_display.svg)

--- a/projects/tt3679.md
+++ b/projects/tt3679.md
@@ -1,0 +1,19 @@
+# Full Adder
+
+**Source:** [https://github.com/Maximillian-Udar/TT](https://github.com/Maximillian-Udar/TT)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3679](https://app.tinytapeout.com/projects/3679)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| A | input | 1 |
+| B | input | 1 |
+| Cin | input | 1 |
+| Sum | output | 1 |
+| Cout | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3679_full_adder.svg)

--- a/projects/tt3680.md
+++ b/projects/tt3680.md
@@ -1,0 +1,17 @@
+# nand_gate
+
+**Source:** [https://github.com/exp10r3/nand_gate](https://github.com/exp10r3/nand_gate)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3680](https://app.tinytapeout.com/projects/3680)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3680_nand.svg)

--- a/projects/tt3681.md
+++ b/projects/tt3681.md
@@ -1,0 +1,17 @@
+# MJ Wokwi project (Full Adder)
+
+**Source:** [https://github.com/mjuels/tinytapeoutworkshop](https://github.com/mjuels/tinytapeoutworkshop)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3681](https://app.tinytapeout.com/projects/3681)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3681_full_adder.svg)

--- a/projects/tt3682.md
+++ b/projects/tt3682.md
@@ -1,0 +1,18 @@
+# I2C to SPI Bridge
+
+**Source:** [https://github.com/vermiscore/ttihp26a-i2c-spi-bridge](https://github.com/vermiscore/ttihp26a-i2c-spi-bridge)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3682](https://app.tinytapeout.com/projects/3682)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3682_bridge.svg)

--- a/projects/tt3684.md
+++ b/projects/tt3684.md
@@ -1,0 +1,16 @@
+# 7 Segment BCD / CLA
+
+**Source:** [https://github.com/gcgc321/Tiny-Tapeout-Carry-Look-Ahead-Adder](https://github.com/gcgc321/Tiny-Tapeout-Carry-Look-Ahead-Adder)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3684](https://app.tinytapeout.com/projects/3684)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3684_cla_bcd.svg)

--- a/projects/tt3685.md
+++ b/projects/tt3685.md
@@ -1,0 +1,16 @@
+# Paafus First Chip
+
+**Source:** [https://github.com/Paafu/Create-the-GDS](https://github.com/Paafu/Create-the-GDS)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3685](https://app.tinytapeout.com/projects/3685)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3685_paafu.svg)

--- a/projects/tt3686.md
+++ b/projects/tt3686.md
@@ -1,0 +1,17 @@
+# MyFirstChip (Patterns)
+
+**Source:** [https://github.com/pablo-dk/TinyTapeoutDTU_chip](https://github.com/pablo-dk/TinyTapeoutDTU_chip)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3686](https://app.tinytapeout.com/projects/3686)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3686_chip.svg)

--- a/projects/tt3687.md
+++ b/projects/tt3687.md
@@ -1,0 +1,18 @@
+# Half Adder
+
+**Source:** [https://github.com/Abdulah-Korishe/Abdulah-s-1st-tiny-tapeout-design](https://github.com/Abdulah-Korishe/Abdulah-s-1st-tiny-tapeout-design)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3687](https://app.tinytapeout.com/projects/3687)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0] | input | 1 |
+| ui[1] | input | 1 |
+| uo[0] | output | 1 |
+| uo[1] | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3687_half_adder.svg)

--- a/projects/tt3688.md
+++ b/projects/tt3688.md
@@ -1,0 +1,16 @@
+# idk
+
+**Source:** [https://github.com/jfho/tt-chip](https://github.com/jfho/tt-chip)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3688](https://app.tinytapeout.com/projects/3688)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3688_idk.svg)

--- a/projects/tt3689.md
+++ b/projects/tt3689.md
@@ -1,0 +1,18 @@
+# Simple Counter (Ripple Counter)
+
+**Source:** [https://github.com/McHerman/Tinytapeout](https://github.com/McHerman/Tinytapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3689](https://app.tinytapeout.com/projects/3689)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3689_simple_counter.svg)

--- a/projects/tt3691.md
+++ b/projects/tt3691.md
@@ -1,0 +1,17 @@
+# Hello World (Logic gates)
+
+**Source:** [https://github.com/Sirius-DK/456571875721383937](https://github.com/Sirius-DK/456571875721383937)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3691](https://app.tinytapeout.com/projects/3691)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3691_hello.svg)

--- a/projects/tt3692.md
+++ b/projects/tt3692.md
@@ -1,0 +1,20 @@
+# SPI RAM Driver
+
+**Source:** [https://github.com/Romultra/2-bit-adder-TTIHP26a](https://github.com/Romultra/2-bit-adder-TTIHP26a)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3692](https://app.tinytapeout.com/projects/3692)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| uo[0:7] | output | 8 |
+| uio[0] | output | 1 |
+| uio[1] | output | 1 |
+| uio[2] | input | 1 |
+| uio[3] | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3692_spi_ram.svg)

--- a/projects/tt3693.md
+++ b/projects/tt3693.md
@@ -1,0 +1,16 @@
+# TinyTapeNkTest
+
+**Source:** [https://github.com/Niko78a1/tinytapeNK](https://github.com/Niko78a1/tinytapeNK)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3693](https://app.tinytapeout.com/projects/3693)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3693_tiny_tape_nk_test.svg)

--- a/projects/tt3694.md
+++ b/projects/tt3694.md
@@ -1,0 +1,18 @@
+# WIP Bin to Dec (OR Logic)
+
+**Source:** [https://github.com/SciFiCarrot/tiny-tapeout-workshop](https://github.com/SciFiCarrot/tiny-tapeout-workshop)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3694](https://app.tinytapeout.com/projects/3694)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3694_bin2dec_wip.svg)

--- a/projects/tt3695.md
+++ b/projects/tt3695.md
@@ -1,0 +1,18 @@
+# Malthes First Template
+
+**Source:** [https://github.com/Malthe2512/Tinytape](https://github.com/Malthe2512/Tinytape)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3695](https://app.tinytapeout.com/projects/3695)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3695_malthe.svg)

--- a/projects/tt3696.md
+++ b/projects/tt3696.md
@@ -1,0 +1,17 @@
+# Alex first circuit (Johnson counter)
+
+**Source:** [https://github.com/5gyyzwxbd4-svg/First](https://github.com/5gyyzwxbd4-svg/First)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3696](https://app.tinytapeout.com/projects/3696)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3696_circuit.svg)

--- a/projects/tt3697.md
+++ b/projects/tt3697.md
@@ -1,0 +1,16 @@
+# GDS Test (Inverter + Pass-through)
+
+**Source:** [https://github.com/Daddybot/GDS](https://github.com/Daddybot/GDS)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3697](https://app.tinytapeout.com/projects/3697)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3697_gds_test.svg)

--- a/projects/tt3698.md
+++ b/projects/tt3698.md
@@ -1,0 +1,16 @@
+# 4-bit full adder
+
+**Source:** [https://github.com/DragonDavid75/TinyTapeoutProjectWokwi](https://github.com/DragonDavid75/TinyTapeoutProjectWokwi)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3698](https://app.tinytapeout.com/projects/3698)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3698_4_bit_full_adder.svg)

--- a/projects/tt3699.md
+++ b/projects/tt3699.md
@@ -1,0 +1,18 @@
+# Tiny Tapeout First Design (Logic Gates)
+
+**Source:** [https://github.com/Skillygonzales/tiny_tapeout_demo](https://github.com/Skillygonzales/tiny_tapeout_demo)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3699](https://app.tinytapeout.com/projects/3699)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3699_first_design.svg)

--- a/projects/tt3700.md
+++ b/projects/tt3700.md
@@ -1,0 +1,18 @@
+# One One
+
+**Source:** [https://github.com/gusish89/tinytapeout_wokwi0](https://github.com/gusish89/tinytapeout_wokwi0)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3700](https://app.tinytapeout.com/projects/3700)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3700_one_one.svg)

--- a/projects/tt3701.md
+++ b/projects/tt3701.md
@@ -1,0 +1,16 @@
+# Cremedelcreme
+
+**Source:** [https://github.com/celien-14/cremedelacreme](https://github.com/celien-14/cremedelacreme)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3701](https://app.tinytapeout.com/projects/3701)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3701.svg)

--- a/projects/tt3702.md
+++ b/projects/tt3702.md
@@ -1,0 +1,16 @@
+# Test Gates
+
+**Source:** [https://github.com/AxuanW/wokwi-template](https://github.com/AxuanW/wokwi-template)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3702](https://app.tinytapeout.com/projects/3702)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0:7] | input | 8 |
+| uo[0:7] | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3702_test_gates.svg)

--- a/projects/tt3703.md
+++ b/projects/tt3703.md
@@ -1,0 +1,16 @@
+# And_Or
+
+**Source:** [https://github.com/David-Weis/Wokwi-chip-design](https://github.com/David-Weis/Wokwi-chip-design)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3703](https://app.tinytapeout.com/projects/3703)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3703_and_or.svg)

--- a/projects/tt3704.md
+++ b/projects/tt3704.md
@@ -1,0 +1,16 @@
+# Hello GDS
+
+**Source:** [https://github.com/edga/tt_hello_gds](https://github.com/edga/tt_hello_gds)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3704](https://app.tinytapeout.com/projects/3704)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3704_hello.svg)

--- a/projects/tt3705.md
+++ b/projects/tt3705.md
@@ -1,0 +1,17 @@
+# demo_chip
+
+**Source:** [https://github.com/carlhyldborglundstroem-code/TinyTapeoutCarlHL](https://github.com/carlhyldborglundstroem-code/TinyTapeoutCarlHL)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3705](https://app.tinytapeout.com/projects/3705)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3705_demo_chip.svg)

--- a/projects/tt3706.md
+++ b/projects/tt3706.md
@@ -1,0 +1,16 @@
+# Scott's first Wokwi design
+
+**Source:** [https://github.com/giffel1/Scott-s-first-Wokwi-design](https://github.com/giffel1/Scott-s-first-Wokwi-design)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3706](https://app.tinytapeout.com/projects/3706)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3706.svg)

--- a/projects/tt3707.md
+++ b/projects/tt3707.md
@@ -1,0 +1,18 @@
+# tinytapeout_henningp_2bin_to_4bit_decoder
+
+**Source:** [https://wokwi.com/projects/456576419565744129](https://wokwi.com/projects/456576419565744129)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3707](https://app.tinytapeout.com/projects/3707)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3707_decoder.svg)

--- a/projects/tt3708.md
+++ b/projects/tt3708.md
@@ -1,0 +1,16 @@
+# My first design
+
+**Source:** [https://github.com/vntinas/My_Test_design](https://github.com/vntinas/My_Test_design)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3708](https://app.tinytapeout.com/projects/3708)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3708_my_first_design.svg)

--- a/projects/tt3709.md
+++ b/projects/tt3709.md
@@ -1,0 +1,19 @@
+# TTIHP26a_Luke_Meta
+
+**Source:** [https://github.com/lucapezza/ttIHP26a_luke_meta](https://github.com/lucapezza/ttIHP26a_luke_meta)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3709](https://app.tinytapeout.com/projects/3709)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| rst_n | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3709_luke_meta.svg)

--- a/projects/tt3710.md
+++ b/projects/tt3710.md
@@ -1,0 +1,19 @@
+# Undecided
+
+**Source:** [https://github.com/schoeberl/ttihp-undecided](https://github.com/schoeberl/ttihp-undecided)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3710](https://app.tinytapeout.com/projects/3710)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| rst_n | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO_IN | input | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3710_undecided.svg)

--- a/projects/tt3711.md
+++ b/projects/tt3711.md
@@ -1,0 +1,16 @@
+# Tiny Tapeout Workshop Test (NAND)
+
+**Source:** [https://github.com/ds-anik/Tiny-Tapeout](https://github.com/ds-anik/Tiny-Tapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3711](https://app.tinytapeout.com/projects/3711)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3711_gates.svg)

--- a/projects/tt3712.md
+++ b/projects/tt3712.md
@@ -1,0 +1,16 @@
+# Amaury Basic Test
+
+**Source:** [https://github.com/Ora-ng3/tiny-tapeout-basic](https://github.com/Ora-ng3/tiny-tapeout-basic)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3712](https://app.tinytapeout.com/projects/3712)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0:7] | input | 8 |
+| uo[0:7] | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3712_basic_test.svg)

--- a/projects/tt3713.md
+++ b/projects/tt3713.md
@@ -1,0 +1,18 @@
+# JayF-HA
+
+**Source:** [https://github.com/Jfvind/tt-jfvind](https://github.com/Jfvind/tt-jfvind)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3713](https://app.tinytapeout.com/projects/3713)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3713_jayf_ha.svg)

--- a/projects/tt3714.md
+++ b/projects/tt3714.md
@@ -1,0 +1,18 @@
+# First tinytapeout 234 (Logic & Pass-through)
+
+**Source:** [https://github.com/anilthilsted/tinytapeout_first](https://github.com/anilthilsted/tinytapeout_first)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3714](https://app.tinytapeout.com/projects/3714)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3714_first_tt.svg)

--- a/projects/tt3715.md
+++ b/projects/tt3715.md
@@ -1,0 +1,17 @@
+# Switch deBounce for Rotary Encoder
+
+**Source:** [https://github.com/GustafsonA/TT26](https://github.com/GustafsonA/TT26)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3715](https://app.tinytapeout.com/projects/3715)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3715_debounce.svg)

--- a/projects/tt3716.md
+++ b/projects/tt3716.md
@@ -1,0 +1,18 @@
+# Tiny Tapeout chip
+
+**Source:** [https://github.com/Birkwk/Chip](https://github.com/Birkwk/Chip)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3716](https://app.tinytapeout.com/projects/3716)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3716.svg)

--- a/projects/tt3717.md
+++ b/projects/tt3717.md
@@ -1,0 +1,17 @@
+# ISC77x8 Side Scrolling Display
+
+**Source:** [https://github.com/HansAdam2077/ISC77x8](https://github.com/HansAdam2077/ISC77x8)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3717](https://app.tinytapeout.com/projects/3717)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| ui[0:7] | input | 8 |
+| uo[0:7] | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3717_isc77x8.svg)

--- a/projects/tt3718.md
+++ b/projects/tt3718.md
@@ -1,0 +1,18 @@
+# Hidden combination
+
+**Source:** [https://github.com/johannakin1/Hemmeligkode](https://github.com/johannakin1/Hemmeligkode)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3718](https://app.tinytapeout.com/projects/3718)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3718_hidden_combination.svg)

--- a/projects/tt3719.md
+++ b/projects/tt3719.md
@@ -1,0 +1,18 @@
+# Test (XOR & D-FlipFlop)
+
+**Source:** [https://github.com/Heinikm/TinyTapeout](https://github.com/Heinikm/TinyTapeout)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3719](https://app.tinytapeout.com/projects/3719)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3719_test.svg)

--- a/projects/tt3720.md
+++ b/projects/tt3720.md
@@ -1,0 +1,16 @@
+# Copenhagen Workshop Project
+
+**Source:** [https://github.com/edwar1r/TinyTapeoutCopenhagenFeb2026](https://github.com/edwar1r/TinyTapeoutCopenhagenFeb2026)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3720](https://app.tinytapeout.com/projects/3720)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3720_copenhagen.svg)

--- a/projects/tt3722.md
+++ b/projects/tt3722.md
@@ -1,0 +1,21 @@
+# Design_test_workshop
+
+**Source:** [https://github.com/donmonki/tt01_chip_design](https://github.com/donmonki/tt01_chip_design)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3722](https://app.tinytapeout.com/projects/3722)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| uio_out | output | 8 |
+| uio_oe | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3722_design_test_workshop.svg)

--- a/projects/tt3723.md
+++ b/projects/tt3723.md
@@ -1,0 +1,16 @@
+# tt3723-7seg-viewer
+
+**Source:** [https://github.com/Ghunk09/ttworkshop_TEST](https://github.com/Ghunk09/ttworkshop_TEST)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3723](https://app.tinytapeout.com/projects/3723)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3723_7seg_viewer.svg)

--- a/projects/tt3724.md
+++ b/projects/tt3724.md
@@ -1,0 +1,18 @@
+# sree
+
+**Source:** [https://wokwi.com/projects/456578694921494529](https://wokwi.com/projects/456578694921494529)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3724](https://app.tinytapeout.com/projects/3724)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3724_sree.svg)

--- a/projects/tt3725.md
+++ b/projects/tt3725.md
@@ -1,0 +1,17 @@
+# Tiny Tapeout Test Gates
+
+**Source:** [https://github.com/YuriiPavlenko-DTU/FIRSTTEST](https://github.com/YuriiPavlenko-DTU/FIRSTTEST)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3725](https://app.tinytapeout.com/projects/3725)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3725_gates.svg)

--- a/projects/tt3726.md
+++ b/projects/tt3726.md
@@ -1,0 +1,18 @@
+# Johnson counter
+
+**Source:** [https://wokwi.com/projects/456019228852926465](https://wokwi.com/projects/456019228852926465)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3726](https://app.tinytapeout.com/projects/3726)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3726_johnson.svg)

--- a/projects/tt3728.md
+++ b/projects/tt3728.md
@@ -1,0 +1,18 @@
+# TestWorkShop
+
+**Source:** [https://github.com/GitteBailey/TinyTapeoutWorkshop](https://github.com/GitteBailey/TinyTapeoutWorkshop)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3728](https://app.tinytapeout.com/projects/3728)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3728_testworkshop.svg)

--- a/projects/tt3729.md
+++ b/projects/tt3729.md
@@ -1,0 +1,21 @@
+# Tiny Tapeout placeholder
+
+**Source:** [https://github.com/martaalfonso/pomasic](https://github.com/martaalfonso/pomasic)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3729](https://app.tinytapeout.com/projects/3729)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| uio_out | output | 8 |
+| uio_oe | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3729_pomasic.svg)

--- a/projects/tt3730.md
+++ b/projects/tt3730.md
@@ -1,0 +1,18 @@
+# Tiny Tapeout Test
+
+**Source:** [https://github.com/kurimm/GitHub-Wokwi-Template](https://github.com/kurimm/GitHub-Wokwi-Template)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3730](https://app.tinytapeout.com/projects/3730)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3730_kristoffer.svg)

--- a/projects/tt3731.md
+++ b/projects/tt3731.md
@@ -1,0 +1,19 @@
+# fullAdder
+
+**Source:** [https://github.com/Nazgul-0/tinytapeoutGDS](https://github.com/Nazgul-0/tinytapeoutGDS)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3731](https://app.tinytapeout.com/projects/3731)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| A | input | 1 |
+| B | input | 1 |
+| Cin | input | 1 |
+| Sum | output | 1 |
+| Cout | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3731.svg)

--- a/projects/tt3733.md
+++ b/projects/tt3733.md
@@ -1,0 +1,19 @@
+# Smart LED digital
+
+**Source:** [https://github.com/hoene/tt_um_hoene_smart_led_digital](https://github.com/hoene/tt_um_hoene_smart_led_digital)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3733](https://app.tinytapeout.com/projects/3733)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| rst_n | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3733_smart_led.svg)

--- a/projects/tt3734.md
+++ b/projects/tt3734.md
@@ -1,0 +1,21 @@
+# test project
+
+**Source:** [https://github.com/tarkor111/tiny-tapeout-design](https://github.com/tarkor111/tiny-tapeout-design)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3734](https://app.tinytapeout.com/projects/3734)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| uio_out | output | 8 |
+| uio_oe | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3734_test_project.svg)

--- a/projects/tt3735.md
+++ b/projects/tt3735.md
@@ -1,0 +1,18 @@
+# Workshop
+
+**Source:** [https://github.com/MikkelKofoed/TinyTapeoutWorkshop](https://github.com/MikkelKofoed/TinyTapeoutWorkshop)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3735](https://app.tinytapeout.com/projects/3735)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3735_workshop.svg)

--- a/projects/tt3736.md
+++ b/projects/tt3736.md
@@ -1,0 +1,19 @@
+# Linear Timecode (LTC) generator
+
+**Source:** [https://github.com/flummer/tt-um-flummer-ltc](https://github.com/flummer/tt-um-flummer-ltc)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3736](https://app.tinytapeout.com/projects/3736)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| rst_n | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3736_ltc_gen.svg)

--- a/projects/tt3737.md
+++ b/projects/tt3737.md
@@ -1,0 +1,18 @@
+# Verilog ring oscillator V2
+
+**Source:** [https://github.com/ChiranjitPatel/tt_ihp26a_ringosc_stdcell](https://github.com/ChiranjitPatel/tt_ihp26a_ringosc_stdcell)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3737](https://app.tinytapeout.com/projects/3737)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3737_ringosc.svg)

--- a/projects/tt3738.md
+++ b/projects/tt3738.md
@@ -1,0 +1,18 @@
+# ADPLL
+
+**Source:** [https://github.com/chrbirks/tt-2026](https://github.com/chrbirks/tt-2026)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3738](https://app.tinytapeout.com/projects/3738)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| rst_n | input | 1 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3738_adpll.svg)

--- a/projects/tt3740.md
+++ b/projects/tt3740.md
@@ -1,0 +1,19 @@
+# tiny_tester
+
+**Source:** [https://github.com/jalcim/tiny_tester](https://github.com/jalcim/tiny_tester)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3740](https://app.tinytapeout.com/projects/3740)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| rst_n | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO_IN | input | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3740_tiny_tester.svg)

--- a/projects/tt3743.md
+++ b/projects/tt3743.md
@@ -1,0 +1,18 @@
+# Wedgetail TCDE REV01
+
+**Source:** [https://github.com/SiliconPlatformsLab/wedgetail-tester-tt-ihp26a](https://github.com/SiliconPlatformsLab/wedgetail-tester-tt-ihp26a)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3743](https://app.tinytapeout.com/projects/3743)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| rst_n | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3743_wedgetail.svg)

--- a/projects/tt3744.md
+++ b/projects/tt3744.md
@@ -1,0 +1,19 @@
+# FABulous FPGA
+
+**Source:** [https://github.com/mole99/tt-fabulous-ihp-26a](https://github.com/mole99/tt-fabulous-ihp-26a)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3744](https://app.tinytapeout.com/projects/3744)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| rst_n | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3744_fabulous.svg)

--- a/projects/tt3745.md
+++ b/projects/tt3745.md
@@ -1,0 +1,19 @@
+# Lab and Lectures SoC
+
+**Source:** [https://github.com/alokerdas/tt_um_ihp26a_LnL_SoC](https://github.com/alokerdas/tt_um_ihp26a_LnL_SoC)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3745](https://app.tinytapeout.com/projects/3745)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| rst_n | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3745_soc.svg)

--- a/projects/tt3747.md
+++ b/projects/tt3747.md
@@ -1,0 +1,19 @@
+# ttihp-HDSISO8
+
+**Source:** [https://github.com/ygdes/ttihp-HDSISO8](https://github.com/ygdes/ttihp-HDSISO8)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3747](https://app.tinytapeout.com/projects/3747)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| rst_n | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3747_hdsiso8.svg)

--- a/projects/tt3753.md
+++ b/projects/tt3753.md
@@ -1,0 +1,18 @@
+# FOMO
+
+**Source:** [https://github.com/algofoogle/ttihp26a-fomo](https://github.com/algofoogle/ttihp26a-fomo)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3753](https://app.tinytapeout.com/projects/3753)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| rst_n | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3753_fomo.svg)

--- a/projects/tt3755.md
+++ b/projects/tt3755.md
@@ -1,0 +1,19 @@
+# Tiny Tapeout Factory Test for ttihp-timer
+
+**Source:** [https://github.com/ZeduloAdmin/ttihp-timer](https://github.com/ZeduloAdmin/ttihp-timer)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3755](https://app.tinytapeout.com/projects/3755)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3755_timer_test.svg)

--- a/projects/tt3756.md
+++ b/projects/tt3756.md
@@ -1,0 +1,17 @@
+# Photo Frame
+
+**Source:** [https://github.com/MichaelBell/ttihp26a-photo-frame](https://github.com/MichaelBell/ttihp26a-photo-frame)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3756](https://app.tinytapeout.com/projects/3756)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| clk | clock | 1 |
+| rst_n | input | 1 |
+| uo_out | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3756_photo_frame.svg)

--- a/projects/tt3757.md
+++ b/projects/tt3757.md
@@ -1,0 +1,21 @@
+# Neuromorphic Tile
+
+**Source:** [https://github.com/crockpotveggies/neuron-ttihp](https://github.com/crockpotveggies/neuron-ttihp)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3757](https://app.tinytapeout.com/projects/3757)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| uio_out | output | 8 |
+| uio_oe | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3757_neuron.svg)

--- a/projects/tt3758.md
+++ b/projects/tt3758.md
@@ -1,0 +1,19 @@
+# miniMAC
+
+**Source:** [https://github.com/YannGuidon/miniMAC_tx](https://github.com/YannGuidon/miniMAC_tx)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3758](https://app.tinytapeout.com/projects/3758)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3758_minimac.svg)

--- a/projects/tt3759.md
+++ b/projects/tt3759.md
@@ -1,0 +1,21 @@
+# test hard macro
+
+**Source:** [https://github.com/jalcim/ttihp-jalcim_ihp_analog_tester](https://github.com/jalcim/ttihp-jalcim_ihp_analog_tester)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3759](https://app.tinytapeout.com/projects/3759)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| A | input | 4 |
+| B | input | 4 |
+| Cin | input | 1 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| Sum | output | 4 |
+| Cout | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3759_adder4b.svg)

--- a/projects/tt3763.md
+++ b/projects/tt3763.md
@@ -1,0 +1,19 @@
+# Canright SBOX
+
+**Source:** [https://github.com/coastalwhite/tinytapeout-ihp-canright](https://github.com/coastalwhite/tinytapeout-ihp-canright)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3763](https://app.tinytapeout.com/projects/3763)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3763_canright_sbox.svg)

--- a/projects/tt3764.md
+++ b/projects/tt3764.md
@@ -1,0 +1,17 @@
+# Silly Mixer
+
+**Source:** [https://github.com/BoredSemiRetiredEngineer/ttihp_submission_other_tile](https://github.com/BoredSemiRetiredEngineer/ttihp_submission_other_tile)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3764](https://app.tinytapeout.com/projects/3764)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO_IN | input | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3764_mixer.svg)

--- a/projects/tt3765.md
+++ b/projects/tt3765.md
@@ -1,0 +1,19 @@
+# E-Beam Inspection Pixel Core
+
+**Source:** [https://github.com/ermalfierza1/E-Beam-Inspection-Pixel-Core](https://github.com/ermalfierza1/E-Beam-Inspection-Pixel-Core)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3765](https://app.tinytapeout.com/projects/3765)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3765_ebeam.svg)

--- a/projects/tt3766.md
+++ b/projects/tt3766.md
@@ -1,0 +1,20 @@
+# 8-bit SEM Floating-Point Multiplier
+
+**Source:** [https://github.com/DelosReyesJordan/ttihp26a-FP8-SEM-Multiplier](https://github.com/DelosReyesJordan/ttihp26a-FP8-SEM-Multiplier)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3766](https://app.tinytapeout.com/projects/3766)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| ENA | input | 1 |
+| A | input | 8 |
+| B | inout | 8 |
+| RESULT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3766.svg)

--- a/projects/tt3768.md
+++ b/projects/tt3768.md
@@ -1,0 +1,18 @@
+# Kalman Filter for IMU
+
+**Source:** [https://github.com/intv0id/tt-ihp-TinyKalman](https://github.com/intv0id/tt-ihp-TinyKalman)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3768](https://app.tinytapeout.com/projects/3768)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3768_kalman_filter.svg)

--- a/projects/tt3769.md
+++ b/projects/tt3769.md
@@ -1,0 +1,25 @@
+# VGA Tetris
+
+**Source:** [https://github.com/JPGHhb/ttihp-vga-tetris](https://github.com/JPGHhb/ttihp-vga-tetris)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3769](https://app.tinytapeout.com/projects/3769)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| LEFT | input | 1 |
+| RIGHT | input | 1 |
+| ROTATE | input | 1 |
+| DOWN | input | 1 |
+| R | output | 2 |
+| G | output | 2 |
+| B | output | 2 |
+| VSYNC | output | 1 |
+| HSYNC | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3769_vga_tetris.svg)

--- a/projects/tt3771.md
+++ b/projects/tt3771.md
@@ -1,0 +1,21 @@
+# Count To Ten
+
+**Source:** [https://github.com/Isk1337/Count-To-Ten](https://github.com/Isk1337/Count-To-Ten)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3771](https://app.tinytapeout.com/projects/3771)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| uio_out | output | 8 |
+| uio_oe | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3771_count_to_ten.svg)

--- a/projects/tt3772.md
+++ b/projects/tt3772.md
@@ -1,0 +1,21 @@
+# ttihp-26a-risc-v-wg-swc1
+
+**Source:** [https://github.com/risc-v-wg/ttihp-26a-risc-v-wg-swc1](https://github.com/risc-v-wg/ttihp-26a-risc-v-wg-swc1)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3772](https://app.tinytapeout.com/projects/3772)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| uio_out | output | 8 |
+| uio_oe | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3772_riscv_rv32i.svg)

--- a/projects/tt3775.md
+++ b/projects/tt3775.md
@@ -1,0 +1,19 @@
+# LoRa Edge SoC
+
+**Source:** [https://github.com/TechHU-GS/tt_rv32_trial](https://github.com/TechHU-GS/tt_rv32_trial)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3775](https://app.tinytapeout.com/projects/3775)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ENA | input | 1 |
+| RST_N | input | 1 |
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3775_lora_soc.svg)

--- a/projects/tt3782.md
+++ b/projects/tt3782.md
@@ -1,0 +1,16 @@
+# Chip ROM
+
+**Source:** [https://github.com/TinyTapeout/tt-chip-rom](https://github.com/TinyTapeout/tt-chip-rom)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3782](https://app.tinytapeout.com/projects/3782)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0:7] | input | 8 |
+| uo[0:7] | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3782_chip_rom.svg)

--- a/projects/tt3802.md
+++ b/projects/tt3802.md
@@ -1,0 +1,20 @@
+# 1-bit counter and 2-to-4 decoder
+
+**Source:** [https://github.com/kapis20/tiny_tapeout_template](https://github.com/kapis20/tiny_tapeout_template)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3802](https://app.tinytapeout.com/projects/3802)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[0] | input | 1 |
+| ui[1] | input | 1 |
+| ui[6] | input | 1 |
+| ui[7] | input | 1 |
+| uo[0] | output | 1 |
+| uo[4:7] | output | 4 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3802_counter_decoder.svg)

--- a/projects/tt3812.md
+++ b/projects/tt3812.md
@@ -1,0 +1,18 @@
+# Hardware UTF Encoder/Decoder
+
+**Source:** [https://github.com/RebeccaRGB/hardware-utf8](https://github.com/RebeccaRGB/hardware-utf8)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3812](https://app.tinytapeout.com/projects/3812)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui[4] | input | 1 |
+| ui[5] | input | 1 |
+| uo[0] | output | 1 |
+| uio[0:7] | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3812_utf8.svg)

--- a/projects/tt3948.md
+++ b/projects/tt3948.md
@@ -1,0 +1,19 @@
+# SEQ_MAC_INF_16H3 - Neural Network Inference Accelerator
+
+**Source:** [https://github.com/Neuromurf/ttihp26a-inferenceFCNN-16h3](https://github.com/Neuromurf/ttihp26a-inferenceFCNN-16h3)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3948](https://app.tinytapeout.com/projects/3948)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3948_seq_mac_inf.svg)

--- a/projects/tt3949.md
+++ b/projects/tt3949.md
@@ -1,0 +1,21 @@
+# 8-bit Prime Number Detector
+
+**Source:** [https://github.com/obrhubr/ttihp-submission](https://github.com/obrhubr/ttihp-submission)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3949](https://app.tinytapeout.com/projects/3949)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| uio_out | output | 8 |
+| uio_oe | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3949_prime_detector.svg)

--- a/projects/tt3957.md
+++ b/projects/tt3957.md
@@ -1,0 +1,18 @@
+# VoGAl
+
+**Source:** [https://github.com/michaelstambach/vogal](https://github.com/michaelstambach/vogal)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3957](https://app.tinytapeout.com/projects/3957)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3957_vogal.svg)

--- a/projects/tt3970.md
+++ b/projects/tt3970.md
@@ -1,0 +1,18 @@
+# smolCPU
+
+**Source:** [https://github.com/TscherterJunior/tt_um_TscherterJunior_top](https://github.com/TscherterJunior/tt_um_TscherterJunior_top)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3970](https://app.tinytapeout.com/projects/3970)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3970_smolcpu.svg)

--- a/projects/tt3974.md
+++ b/projects/tt3974.md
@@ -1,0 +1,21 @@
+# O2ELHd 7segment display
+
+**Source:** [https://github.com/OzelHD/wokwi_test](https://github.com/OzelHD/wokwi_test)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3974](https://app.tinytapeout.com/projects/3974)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| A | input | 1 |
+| B | input | 1 |
+| C | input | 1 |
+| SEG | output | 7 |
+| DOT | output | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3974_7seg_display.svg)

--- a/projects/tt3975.md
+++ b/projects/tt3975.md
@@ -1,0 +1,18 @@
+# vga_ca
+
+**Source:** [https://github.com/znah/ihp-ca](https://github.com/znah/ihp-ca)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3975](https://app.tinytapeout.com/projects/3975)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| CLK | input | 1 |
+| RST_N | input | 1 |
+| UO_OUT | output | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3975_vgaca.svg)

--- a/projects/tt3978.md
+++ b/projects/tt3978.md
@@ -1,0 +1,18 @@
+# SIMON
+
+**Source:** [https://github.com/libormiller/ttihp-simon](https://github.com/libormiller/ttihp-simon)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3978](https://app.tinytapeout.com/projects/3978)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| uio_in | input | 8 |
+| uio_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3978_simon.svg)

--- a/projects/tt3979.md
+++ b/projects/tt3979.md
@@ -1,0 +1,20 @@
+# Tschai's Tic-Tac-Toe
+
+**Source:** [https://github.com/tschai-yim/ttihp-mill](https://github.com/tschai-yim/ttihp-mill)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3979](https://app.tinytapeout.com/projects/3979)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| CLK | clock | 1 |
+| RST_N | input | 1 |
+| BTN | input | 8 |
+| LED | output | 8 |
+| BTN_BR | inout | 1 |
+| LED_BR | inout | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3979_tictactoe.svg)

--- a/projects/tt3988.md
+++ b/projects/tt3988.md
@@ -1,0 +1,17 @@
+# microlane demo project
+
+**Source:** [https://github.com/htfab/ttihp-microlane-demo](https://github.com/htfab/ttihp-microlane-demo)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3988](https://app.tinytapeout.com/projects/3988)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3988_microlane_demo.svg)

--- a/projects/tt3990.md
+++ b/projects/tt3990.md
@@ -1,0 +1,17 @@
+# OCP MXFP8 Streaming MAC Unit
+
+**Source:** [https://github.com/chatelao/ttihp-fp8-mul](https://github.com/chatelao/ttihp-fp8-mul)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3990](https://app.tinytapeout.com/projects/3990)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| UI_IN | input | 8 |
+| UO_OUT | output | 8 |
+| UIO | inout | 8 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3990_fp8_mul.svg)

--- a/projects/tt3991.md
+++ b/projects/tt3991.md
@@ -1,0 +1,21 @@
+# TinyTapeout-Processor2
+
+**Source:** [https://github.com/matei-coder/TinyTapeout-Processor2](https://github.com/matei-coder/TinyTapeout-Processor2)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3991](https://app.tinytapeout.com/projects/3991)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| uio_out | output | 8 |
+| uio_oe | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3991_processor2.svg)

--- a/projects/tt3998.md
+++ b/projects/tt3998.md
@@ -1,0 +1,18 @@
+# tiny_dino
+
+**Source:** [https://github.com/RongGi/tiny_dino](https://github.com/RongGi/tiny_dino)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3998](https://app.tinytapeout.com/projects/3998)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3998_tiny_dino.svg)

--- a/projects/tt3999.md
+++ b/projects/tt3999.md
@@ -1,0 +1,21 @@
+# KianV SV32 TT Linux SoC
+
+**Source:** [https://github.com/splinedrive/kianv-sv32-tt-linux-soc](https://github.com/splinedrive/kianv-sv32-tt-linux-soc)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/3999](https://app.tinytapeout.com/projects/3999)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| uio_out | output | 8 |
+| uio_oe | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt3999_kianv_sv32.svg)

--- a/projects/tt4002.md
+++ b/projects/tt4002.md
@@ -1,0 +1,21 @@
+# Infinity Core
+
+**Source:** [https://github.com/FilteredNoise/tt-infinity-core](https://github.com/FilteredNoise/tt-infinity-core)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/4002](https://app.tinytapeout.com/projects/4002)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| uio_out | output | 8 |
+| uio_oe | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt4002_infinity_core.svg)

--- a/projects/tt4003.md
+++ b/projects/tt4003.md
@@ -1,0 +1,21 @@
+# 4-bit processor
+
+**Source:** [https://github.com/alessio8132/IHP26a-4-bit-processor](https://github.com/alessio8132/IHP26a-4-bit-processor)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/4003](https://app.tinytapeout.com/projects/4003)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| uio_out | output | 8 |
+| uio_oe | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt4003_4bit_processor.svg)

--- a/projects/tt4006.md
+++ b/projects/tt4006.md
@@ -1,0 +1,21 @@
+# Custom coprocessor
+
+**Source:** [https://github.com/GianmarcoFortunelli/TT_coprocessor](https://github.com/GianmarcoFortunelli/TT_coprocessor)
+
+**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/4006](https://app.tinytapeout.com/projects/4006)
+
+## Input/Output Definitions
+
+| Signal | Type | Width |
+|--------|------|-------|
+| ui_in | input | 8 |
+| uo_out | output | 8 |
+| uio_in | input | 8 |
+| uio_out | output | 8 |
+| uio_oe | output | 8 |
+| clk | clock | 1 |
+| rst_n | input | 1 |
+
+## Test Waveform
+
+![Waveform](../waveforms/tt4006_coprocessor.svg)

--- a/src/scripts/generate_project_pages.py
+++ b/src/scripts/generate_project_pages.py
@@ -1,0 +1,76 @@
+import os
+import yaml
+import re
+
+def generate_markdown(pid, yaml_data, svg_path):
+    project_name = yaml_data.get('project', f'Project {pid}')
+    source_url = yaml_data.get('metadata', {}).get('source', '')
+
+    signals = yaml_data.get('signals', {})
+
+    md_content = f"# {project_name}\n\n"
+
+    if source_url:
+        md_content += f"**Source:** [{source_url}]({source_url})\n\n"
+
+    md_content += f"**TinyTapeout Project Page:** [https://app.tinytapeout.com/projects/{pid}](https://app.tinytapeout.com/projects/{pid})\n\n"
+
+    md_content += "## Input/Output Definitions\n\n"
+    md_content += "| Signal | Type | Width |\n"
+    md_content += "|--------|------|-------|\n"
+
+    for sig_name, sig_info in signals.items():
+        stype = sig_info.get('type', 'N/A')
+        width = sig_info.get('width', 'N/A')
+        md_content += f"| {sig_name} | {stype} | {width} |\n"
+
+    md_content += "\n## Test Waveform\n\n"
+    if svg_path and os.path.exists(svg_path):
+        md_content += f"![Waveform](../{svg_path})\n"
+    else:
+        md_content += "Waveform not available.\n"
+
+    return md_content
+
+def main():
+    data_dir = 'src/data'
+    projects_dir = 'projects'
+    waveforms_dir = 'waveforms'
+
+    if not os.path.exists(projects_dir):
+        os.makedirs(projects_dir)
+
+    for filename in os.listdir(data_dir):
+        if filename.endswith('.yaml') and filename.startswith('tt'):
+            match = re.search(r'tt(\d+)', filename)
+            if not match:
+                continue
+            pid = match.group(1)
+
+            yaml_path = os.path.join(data_dir, filename)
+            with open(yaml_path, 'r') as f:
+                try:
+                    yaml_data = yaml.safe_load(f)
+                except yaml.YAMLError:
+                    print(f"Error reading {yaml_path}")
+                    continue
+
+            if not yaml_data:
+                continue
+
+            svg_filename = f"tt{pid}"
+            # Need to find the actual SVG as it might have suffix
+            svg_path = ""
+            for f in os.listdir(waveforms_dir):
+                if f.startswith(f"tt{pid}") and f.endswith(".svg"):
+                    svg_path = os.path.join(waveforms_dir, f)
+                    break
+
+            md_content = generate_markdown(pid, yaml_data, svg_path)
+
+            with open(os.path.join(projects_dir, f"tt{pid}.md"), 'w') as f:
+                f.write(md_content)
+            print(f"Generated projects/tt{pid}.md")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This change adds a new `/projects` directory containing automatically generated markdown documentation for all testable projects. Each markdown file includes:
- Project title and source repository link.
- Link to the official TinyTapeout project page.
- A table defining all input and output signals (name, type, width).
- An embedded SVG waveform image illustrating the test sequence.

A new script `src/scripts/generate_project_pages.py` was added to maintain these summaries as the project data evolves.

Fixes #112

---
*PR created automatically by Jules for task [16764606321675815916](https://jules.google.com/task/16764606321675815916) started by @chatelao*