### PR TITLE
Link project summaries to documentation in overview table

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -14,6 +14,7 @@
 ## Finishing
 - Check the boxes of solved tasks in the ROADMAP.md
 - Be sure all /src/data have generated /waveforms
+- Ensure that in `src/docs/TTIHP26A_PROJECTS.md`, the "Summary" column links to the corresponding `src/docs/tt{ID}.md` file if it exists.
 
 # Project structure
 - ROADMAP.md - Planned & finished tasks of the product

--- a/src/docs/TTIHP26A_PROJECTS.md
+++ b/src/docs/TTIHP26A_PROJECTS.md
@@ -4,288 +4,288 @@
 
 | Summary | Novelty | T-shirt size | Test Data | Waveform | TinyTapeout Page |
 |---------|---------|--------------|-----------|----------|------------------|
-| FABulous FPGA | ⭐⭐⭐⭐⭐ | XXXL | [YAML](../data/tt3744_fabulous.yaml) | [SVG](../../waveforms/tt3744_fabulous.svg) | [Project 3744](https://app.tinytapeout.com/projects/3744) |
-| KianV SV32 TT Linux SoC | ⭐⭐⭐⭐⭐ | XXXL | [YAML](../data/tt3999_kianv_sv32.yaml) | [SVG](../../waveforms/tt3999_uio_in.svg) | [Project 3999](https://app.tinytapeout.com/projects/3999) |
-| TinyQV Risc-V SoC | ⭐⭐⭐⭐⭐ | XXL | [YAML](../data/tt3435_tinyqv.yaml) | [SVG](../../waveforms/tt3435_tinyqv.svg) | [Project 3435](https://app.tinytapeout.com/projects/3435) |
-| SotaSoC | ⭐⭐⭐⭐⭐ | XXL | [YAML](../data/tt3543_sotasoc.yaml) | [SVG](../../waveforms/tt3543_sotasoc.svg) | [Project 3543](https://app.tinytapeout.com/projects/3543) |
-| TinyMOA: RISC-V CPU with CIM Accelerator | ⭐⭐⭐⭐⭐ | XXL | [YAML](../data/tt3654_tinymoa.yaml) | [SVG](../../waveforms/tt3654_tinymoa.svg) | [Project 3654](https://app.tinytapeout.com/projects/3654) |
-| ttip-test | ⭐⭐⭐⭐⭐ | XXL | [YAML](../data/tt3662_test.yaml) | [SVG](../../waveforms/tt3662_test.svg) | [Project 3662](https://app.tinytapeout.com/projects/3662) |
-| ttihp-26a-risc-v-wg-swc1 | ⭐⭐⭐⭐⭐ | XXL | [YAML](../data/tt3772_riscv_rv32i.yaml) | [SVG](../../waveforms/tt3772_riscv_rv32i.svg) | [Project 3772](https://app.tinytapeout.com/projects/3772) |
+| [FABulous FPGA](tt3744.md) | ⭐⭐⭐⭐⭐ | XXXL | [YAML](../data/tt3744_fabulous.yaml) | [SVG](../../waveforms/tt3744_fabulous.svg) | [Project 3744](https://app.tinytapeout.com/projects/3744) |
+| [KianV SV32 TT Linux SoC](tt3999.md) | ⭐⭐⭐⭐⭐ | XXXL | [YAML](../data/tt3999_kianv_sv32.yaml) | [SVG](../../waveforms/tt3999_uio_in.svg) | [Project 3999](https://app.tinytapeout.com/projects/3999) |
+| [TinyQV Risc-V SoC](tt3435.md) | ⭐⭐⭐⭐⭐ | XXL | [YAML](../data/tt3435_tinyqv.yaml) | [SVG](../../waveforms/tt3435_tinyqv.svg) | [Project 3435](https://app.tinytapeout.com/projects/3435) |
+| [SotaSoC](tt3543.md) | ⭐⭐⭐⭐⭐ | XXL | [YAML](../data/tt3543_sotasoc.yaml) | [SVG](../../waveforms/tt3543_sotasoc.svg) | [Project 3543](https://app.tinytapeout.com/projects/3543) |
+| [TinyMOA: RISC-V CPU with CIM Accelerator](tt3654.md) | ⭐⭐⭐⭐⭐ | XXL | [YAML](../data/tt3654_tinymoa.yaml) | [SVG](../../waveforms/tt3654_tinymoa.svg) | [Project 3654](https://app.tinytapeout.com/projects/3654) |
+| [ttip-test](tt3662.md) | ⭐⭐⭐⭐⭐ | XXL | [YAML](../data/tt3662_test.yaml) | [SVG](../../waveforms/tt3662_test.svg) | [Project 3662](https://app.tinytapeout.com/projects/3662) |
+| [ttihp-26a-risc-v-wg-swc1](tt3772.md) | ⭐⭐⭐⭐⭐ | XXL | [YAML](../data/tt3772_riscv_rv32i.yaml) | [SVG](../../waveforms/tt3772_riscv_rv32i.svg) | [Project 3772](https://app.tinytapeout.com/projects/3772) |
 | MNIST Binary Neural Net (Inference) | ⭐⭐⭐⭐⭐ | XXL | N/A | N/A | [Project 4096](https://app.tinytapeout.com/projects/4096) |
-| KianV RISC-V RV32E Baremetal SoC | ⭐⭐⭐⭐ | XL | [YAML](../data/tt3420_kianv_rv32e.yaml) | [SVG](../../waveforms/tt3420_kianv_rv32e.svg) | [Project 3420](https://app.tinytapeout.com/projects/3420) |
-| Wildcat RISC-V | ⭐⭐⭐⭐ | XL | [YAML](../data/tt3445_wildcat.yaml) | [SVG](../../waveforms/tt3445_ui_in.svg) | [Project 3445](https://app.tinytapeout.com/projects/3445) |
-| FH Joanneum TinyTapeout | ⭐⭐⭐⭐ | XL | [YAML](../data/tt3531_fh_uc.yaml) | [SVG](../../waveforms/tt3531_fh_uc.svg) | [Project 3531](https://app.tinytapeout.com/projects/3531) |
-| Borg - Vertex shader | ⭐⭐⭐⭐ | XL | [YAML](../data/tt3645_borg.yaml) | [SVG](../../waveforms/tt3645_borg.svg) | [Project 3645](https://app.tinytapeout.com/projects/3645) |
-| LoRa Edge SoC | ⭐⭐⭐⭐ | XL | [YAML](../data/tt3775_lora_soc.yaml) | [SVG](../../waveforms/tt3775_lora_soc.svg) | [Project 3775](https://app.tinytapeout.com/projects/3775) |
-| TinyTapeout-Processor2 | ⭐⭐⭐⭐ | XL | [YAML](../data/tt3991_processor2.yaml) | [SVG](../../waveforms/tt3991_uio_in_load.svg) | [Project 3991](https://app.tinytapeout.com/projects/3991) |
-| 2048 sliding tile puzzle game (VGA) | ⭐⭐⭐⭐ | XL | [YAML](../data/tt4095_vga_2048.yaml) | N/A | [Project 4095](https://app.tinytapeout.com/projects/4095) |
-| SimProc (Simple Processor) | ⭐⭐⭐ | L | [YAML](../data/tt3415_simproc.yaml) | [SVG](../../waveforms/tt3415_uio_in_baud.svg) | [Project 3415](https://app.tinytapeout.com/projects/3415) |
-| 2048 sliding tile puzzle game (VGA) | ⭐⭐⭐ | L | [YAML](../data/tt3425_vga_2048.yaml) | [SVG](../../waveforms/tt3425_vga_2048.svg) | [Project 3425](https://app.tinytapeout.com/projects/3425) |
-| Zilog Z80 | ⭐⭐⭐ | L | [YAML](../data/tt3434_z80.yaml) | [SVG](../../waveforms/tt3434_uo_out.svg) | [Project 3434](https://app.tinytapeout.com/projects/3434) |
-| VGA Drop (audio/visual demo) | ⭐⭐⭐ | L | [YAML](../data/tt3449_vga_drop.yaml) | [SVG](../../waveforms/tt3449_vga_drop.svg) | [Project 3449](https://app.tinytapeout.com/projects/3449) |
-| Herald | ⭐⭐⭐ | L | [YAML](../data/tt3502_herald.yaml) | [SVG](../../waveforms/tt3502_uo_out.svg) | [Project 3502](https://app.tinytapeout.com/projects/3502) |
-| m6502 Microcontroller | ⭐⭐⭐ | L | [YAML](../data/tt3528_m6502.yaml) | [SVG](../../waveforms/tt3528_m6502.svg) | [Project 3528](https://app.tinytapeout.com/projects/3528) |
-| TT6581 | ⭐⭐⭐ | L | [YAML](../data/tt3635_tt6581.yaml) | [SVG](../../waveforms/tt3635_tt6581.svg) | [Project 3635](https://app.tinytapeout.com/projects/3635) |
-| 2x2 Systolic Array | ⭐⭐⭐ | L | [YAML](../data/tt3647_systolic.yaml) | [SVG](../../waveforms/tt3647_systolic.svg) | [Project 3647](https://app.tinytapeout.com/projects/3647) |
-| quad-sieve | ⭐⭐⭐ | L | [YAML](../data/tt3659_quad_sieve.yaml) | [SVG](../../waveforms/tt3659_quad_sieve.svg) | [Project 3659](https://app.tinytapeout.com/projects/3659) |
-| Neuromorphic Tile | ⭐⭐⭐ | L | [YAML](../data/tt3757_neuron.yaml) | [SVG](../../waveforms/tt3757_uo_out.svg) | [Project 3757](https://app.tinytapeout.com/projects/3757) |
-| VGA Tetris | ⭐⭐⭐ | L | [YAML](../data/tt3769_vga_tetris.yaml) | [SVG](../../waveforms/tt3769_vga_tetris.svg) | [Project 3769](https://app.tinytapeout.com/projects/3769) |
-| OCP MXFP8 Streaming MAC Unit | ⭐⭐⭐ | L | [YAML](../data/tt3990_fp8_mul.yaml) | [SVG](../../waveforms/tt3990_uio_in_c2.svg) | [Project 3990](https://app.tinytapeout.com/projects/3990) |
+| [KianV RISC-V RV32E Baremetal SoC](tt3420.md) | ⭐⭐⭐⭐ | XL | [YAML](../data/tt3420_kianv_rv32e.yaml) | [SVG](../../waveforms/tt3420_kianv_rv32e.svg) | [Project 3420](https://app.tinytapeout.com/projects/3420) |
+| [Wildcat RISC-V](tt3445.md) | ⭐⭐⭐⭐ | XL | [YAML](../data/tt3445_wildcat.yaml) | [SVG](../../waveforms/tt3445_ui_in.svg) | [Project 3445](https://app.tinytapeout.com/projects/3445) |
+| [FH Joanneum TinyTapeout](tt3531.md) | ⭐⭐⭐⭐ | XL | [YAML](../data/tt3531_fh_uc.yaml) | [SVG](../../waveforms/tt3531_fh_uc.svg) | [Project 3531](https://app.tinytapeout.com/projects/3531) |
+| [Borg - Vertex shader](tt3645.md) | ⭐⭐⭐⭐ | XL | [YAML](../data/tt3645_borg.yaml) | [SVG](../../waveforms/tt3645_borg.svg) | [Project 3645](https://app.tinytapeout.com/projects/3645) |
+| [LoRa Edge SoC](tt3775.md) | ⭐⭐⭐⭐ | XL | [YAML](../data/tt3775_lora_soc.yaml) | [SVG](../../waveforms/tt3775_lora_soc.svg) | [Project 3775](https://app.tinytapeout.com/projects/3775) |
+| [TinyTapeout-Processor2](tt3991.md) | ⭐⭐⭐⭐ | XL | [YAML](../data/tt3991_processor2.yaml) | [SVG](../../waveforms/tt3991_uio_in_load.svg) | [Project 3991](https://app.tinytapeout.com/projects/3991) |
+| [2048 sliding tile puzzle game (VGA)](tt4095.md) | ⭐⭐⭐⭐ | XL | [YAML](../data/tt4095_vga_2048.yaml) | N/A | [Project 4095](https://app.tinytapeout.com/projects/4095) |
+| [SimProc (Simple Processor)](tt3415.md) | ⭐⭐⭐ | L | [YAML](../data/tt3415_simproc.yaml) | [SVG](../../waveforms/tt3415_uio_in_baud.svg) | [Project 3415](https://app.tinytapeout.com/projects/3415) |
+| [2048 sliding tile puzzle game (VGA)](tt3425.md) | ⭐⭐⭐ | L | [YAML](../data/tt3425_vga_2048.yaml) | [SVG](../../waveforms/tt3425_vga_2048.svg) | [Project 3425](https://app.tinytapeout.com/projects/3425) |
+| [Zilog Z80](tt3434.md) | ⭐⭐⭐ | L | [YAML](../data/tt3434_z80.yaml) | [SVG](../../waveforms/tt3434_uo_out.svg) | [Project 3434](https://app.tinytapeout.com/projects/3434) |
+| [VGA Drop (audio/visual demo)](tt3449.md) | ⭐⭐⭐ | L | [YAML](../data/tt3449_vga_drop.yaml) | [SVG](../../waveforms/tt3449_vga_drop.svg) | [Project 3449](https://app.tinytapeout.com/projects/3449) |
+| [Herald](tt3502.md) | ⭐⭐⭐ | L | [YAML](../data/tt3502_herald.yaml) | [SVG](../../waveforms/tt3502_uo_out.svg) | [Project 3502](https://app.tinytapeout.com/projects/3502) |
+| [m6502 Microcontroller](tt3528.md) | ⭐⭐⭐ | L | [YAML](../data/tt3528_m6502.yaml) | [SVG](../../waveforms/tt3528_m6502.svg) | [Project 3528](https://app.tinytapeout.com/projects/3528) |
+| [TT6581](tt3635.md) | ⭐⭐⭐ | L | [YAML](../data/tt3635_tt6581.yaml) | [SVG](../../waveforms/tt3635_tt6581.svg) | [Project 3635](https://app.tinytapeout.com/projects/3635) |
+| [2x2 Systolic Array](tt3647.md) | ⭐⭐⭐ | L | [YAML](../data/tt3647_systolic.yaml) | [SVG](../../waveforms/tt3647_systolic.svg) | [Project 3647](https://app.tinytapeout.com/projects/3647) |
+| [quad-sieve](tt3659.md) | ⭐⭐⭐ | L | [YAML](../data/tt3659_quad_sieve.yaml) | [SVG](../../waveforms/tt3659_quad_sieve.svg) | [Project 3659](https://app.tinytapeout.com/projects/3659) |
+| [Neuromorphic Tile](tt3757.md) | ⭐⭐⭐ | L | [YAML](../data/tt3757_neuron.yaml) | [SVG](../../waveforms/tt3757_uo_out.svg) | [Project 3757](https://app.tinytapeout.com/projects/3757) |
+| [VGA Tetris](tt3769.md) | ⭐⭐⭐ | L | [YAML](../data/tt3769_vga_tetris.yaml) | [SVG](../../waveforms/tt3769_vga_tetris.svg) | [Project 3769](https://app.tinytapeout.com/projects/3769) |
+| [OCP MXFP8 Streaming MAC Unit](tt3990.md) | ⭐⭐⭐ | L | [YAML](../data/tt3990_fp8_mul.yaml) | [SVG](../../waveforms/tt3990_uio_in_c2.svg) | [Project 3990](https://app.tinytapeout.com/projects/3990) |
 | Tiny NPU: 4-Way Parallel INT8 Inference Engine | ⭐⭐⭐ | L | N/A | N/A | [Project 4032](https://app.tinytapeout.com/projects/4032) |
 | Spongent-88 Hash Accelerator | ⭐⭐⭐ | L | N/A | N/A | [Project 4073](https://app.tinytapeout.com/projects/4073) |
-| USB CDC (Serial) Device | ⭐⭐⭐ | L | [YAML](../data/tt4094_usb_cdc.yaml) | N/A | [Project 4094](https://app.tinytapeout.com/projects/4094) |
-| My (S)VGA Playground | ⭐⭐ | M | [YAML](../data/tt3405_vga_playground.yaml) | [SVG](../../waveforms/tt3405_vga_playground.svg) | [Project 3405](https://app.tinytapeout.com/projects/3405) |
-| Wafer.space Logo VGA Screensaver | ⭐⭐ | M | [YAML](../data/tt3432_vga_screensaver.yaml) | [SVG](../../waveforms/tt3432_vga_screensaver.svg) | [Project 3432](https://app.tinytapeout.com/projects/3432) |
-| Simon's Caterpillar | ⭐⭐ | M | [YAML](../data/tt3437_caterpillar.yaml) | [SVG](../../waveforms/tt3437_caterpillar.svg) | [Project 3437](https://app.tinytapeout.com/projects/3437) |
-| Frequency Counter SSD1306 OLED | ⭐⭐ | M | [YAML](../data/tt3462_freq_counter.yaml) | [SVG](../../waveforms/tt3462_freq_counter.svg) | [Project 3462](https://app.tinytapeout.com/projects/3462) |
-| VGA Tiny Logo Roto Zoomer | ⭐⭐ | M | [YAML](../data/tt3489_vga_roto.yaml) | [SVG](../../waveforms/tt3489_ui_in.svg) | [Project 3489](https://app.tinytapeout.com/projects/3489) |
-| VGA Pride | ⭐⭐ | M | [YAML](../data/tt3494_vga_pride.yaml) | [SVG](../../waveforms/tt3494_ui_in.svg) | [Project 3494](https://app.tinytapeout.com/projects/3494) |
-| SnakeGame | ⭐⭐ | M | [YAML](../data/tt3514_snake_game.yaml) | [SVG](../../waveforms/tt3514_snake_game.svg) | [Project 3514](https://app.tinytapeout.com/projects/3514) |
-| Piggybag | ⭐⭐ | M | [YAML](../data/tt3533_piggybag.yaml) | [SVG](../../waveforms/tt3533_piggybag.svg) | [Project 3533](https://app.tinytapeout.com/projects/3533) |
-| M31 Mersenne-31 Arithmetic Accelerator | ⭐⭐ | M | [YAML](../data/tt3641_m31_accel.yaml) | [SVG](../../waveforms/tt3641_m31_accel.svg) | [Project 3641](https://app.tinytapeout.com/projects/3641) |
-| Bit-Serial Collatz Checker | ⭐⭐ | M | [YAML](../data/tt3642_collatz.yaml) | [SVG](../../waveforms/tt3642_collatz.svg) | [Project 3642](https://app.tinytapeout.com/projects/3642) |
-| tophat | ⭐⭐ | M | [YAML](../data/tt3648_tophat.yaml) | [SVG](../../waveforms/tt3648_ui_in.svg) | [Project 3648](https://app.tinytapeout.com/projects/3648) |
-| SID Voice Synthesizer | ⭐⭐ | M | [YAML](../data/tt3653_sid_voice_synthesizer.yaml) | [SVG](../../waveforms/tt3653_ui_in.svg) | [Project 3653](https://app.tinytapeout.com/projects/3653) |
-| LLR simple VGA GPU | ⭐⭐ | M | [YAML](../data/tt3661_vga_gpu.yaml) | [SVG](../../waveforms/tt3661_vga_gpu.svg) | [Project 3661](https://app.tinytapeout.com/projects/3661) |
-| Tiny Tapeout placeholder | ⭐⭐ | M | [YAML](../data/tt3729_pomasic.yaml) | [SVG](../../waveforms/tt3729_uo_out.svg) | [Project 3729](https://app.tinytapeout.com/projects/3729) |
-| Linear Timecode (LTC) generator | ⭐⭐ | M | [YAML](../data/tt3736_ltc_gen.yaml) | [SVG](../../waveforms/tt3736_ltc_gen.svg) | [Project 3736](https://app.tinytapeout.com/projects/3736) |
-| miniMAC | ⭐⭐ | M | [YAML](../data/tt3758_minimac.yaml) | [SVG](../../waveforms/tt3758_ui_in.svg) | [Project 3758](https://app.tinytapeout.com/projects/3758) |
-| test hard macro | ⭐⭐ | M | [YAML](../data/tt3759_adder4b.yaml) | [SVG](../../waveforms/tt3759_adder4b.svg) | [Project 3759](https://app.tinytapeout.com/projects/3759) |
-| E-Beam Inspection Pixel Core | ⭐⭐ | M | [YAML](../data/tt3765_ebeam.yaml) | [SVG](../../waveforms/tt3765_ebeam.svg) | [Project 3765](https://app.tinytapeout.com/projects/3765) |
-| Kalman Filter for IMU | ⭐⭐ | M | [YAML](../data/tt3768_kalman_filter.yaml) | [SVG](../../waveforms/tt3768_ui_in.svg) | [Project 3768](https://app.tinytapeout.com/projects/3768) |
-| SEQ_MAC_INF_16H3 - Neural Network Inference Accelerator | ⭐⭐ | M | [YAML](../data/tt3948_seq_mac_inf.yaml) | [SVG](../../waveforms/tt3948_uio_in.svg) | [Project 3948](https://app.tinytapeout.com/projects/3948) |
-| SIMON | ⭐⭐ | M | [YAML](../data/tt3978_simon.yaml) | [SVG](../../waveforms/tt3978_simon.svg) | [Project 3978](https://app.tinytapeout.com/projects/3978) |
-| Custom coprocessor | ⭐⭐ | M | [YAML](../data/tt4006_coprocessor.yaml) | [SVG](../../waveforms/tt4006_uo_out.svg) | [Project 4006](https://app.tinytapeout.com/projects/4006) |
+| [USB CDC (Serial) Device](tt4094.md) | ⭐⭐⭐ | L | [YAML](../data/tt4094_usb_cdc.yaml) | N/A | [Project 4094](https://app.tinytapeout.com/projects/4094) |
+| [My (S)VGA Playground](tt3405.md) | ⭐⭐ | M | [YAML](../data/tt3405_vga_playground.yaml) | [SVG](../../waveforms/tt3405_vga_playground.svg) | [Project 3405](https://app.tinytapeout.com/projects/3405) |
+| [Wafer.space Logo VGA Screensaver](tt3432.md) | ⭐⭐ | M | [YAML](../data/tt3432_vga_screensaver.yaml) | [SVG](../../waveforms/tt3432_vga_screensaver.svg) | [Project 3432](https://app.tinytapeout.com/projects/3432) |
+| [Simon's Caterpillar](tt3437.md) | ⭐⭐ | M | [YAML](../data/tt3437_caterpillar.yaml) | [SVG](../../waveforms/tt3437_caterpillar.svg) | [Project 3437](https://app.tinytapeout.com/projects/3437) |
+| [Frequency Counter SSD1306 OLED](tt3462.md) | ⭐⭐ | M | [YAML](../data/tt3462_freq_counter.yaml) | [SVG](../../waveforms/tt3462_freq_counter.svg) | [Project 3462](https://app.tinytapeout.com/projects/3462) |
+| [VGA Tiny Logo Roto Zoomer](tt3489.md) | ⭐⭐ | M | [YAML](../data/tt3489_vga_roto.yaml) | [SVG](../../waveforms/tt3489_ui_in.svg) | [Project 3489](https://app.tinytapeout.com/projects/3489) |
+| [VGA Pride](tt3494.md) | ⭐⭐ | M | [YAML](../data/tt3494_vga_pride.yaml) | [SVG](../../waveforms/tt3494_ui_in.svg) | [Project 3494](https://app.tinytapeout.com/projects/3494) |
+| [SnakeGame](tt3514.md) | ⭐⭐ | M | [YAML](../data/tt3514_snake_game.yaml) | [SVG](../../waveforms/tt3514_snake_game.svg) | [Project 3514](https://app.tinytapeout.com/projects/3514) |
+| [Piggybag](tt3533.md) | ⭐⭐ | M | [YAML](../data/tt3533_piggybag.yaml) | [SVG](../../waveforms/tt3533_piggybag.svg) | [Project 3533](https://app.tinytapeout.com/projects/3533) |
+| [M31 Mersenne-31 Arithmetic Accelerator](tt3641.md) | ⭐⭐ | M | [YAML](../data/tt3641_m31_accel.yaml) | [SVG](../../waveforms/tt3641_m31_accel.svg) | [Project 3641](https://app.tinytapeout.com/projects/3641) |
+| [Bit-Serial Collatz Checker](tt3642.md) | ⭐⭐ | M | [YAML](../data/tt3642_collatz.yaml) | [SVG](../../waveforms/tt3642_collatz.svg) | [Project 3642](https://app.tinytapeout.com/projects/3642) |
+| [tophat](tt3648.md) | ⭐⭐ | M | [YAML](../data/tt3648_tophat.yaml) | [SVG](../../waveforms/tt3648_ui_in.svg) | [Project 3648](https://app.tinytapeout.com/projects/3648) |
+| [SID Voice Synthesizer](tt3653.md) | ⭐⭐ | M | [YAML](../data/tt3653_sid_voice_synthesizer.yaml) | [SVG](../../waveforms/tt3653_ui_in.svg) | [Project 3653](https://app.tinytapeout.com/projects/3653) |
+| [LLR simple VGA GPU](tt3661.md) | ⭐⭐ | M | [YAML](../data/tt3661_vga_gpu.yaml) | [SVG](../../waveforms/tt3661_vga_gpu.svg) | [Project 3661](https://app.tinytapeout.com/projects/3661) |
+| [Tiny Tapeout placeholder](tt3729.md) | ⭐⭐ | M | [YAML](../data/tt3729_pomasic.yaml) | [SVG](../../waveforms/tt3729_uo_out.svg) | [Project 3729](https://app.tinytapeout.com/projects/3729) |
+| [Linear Timecode (LTC) generator](tt3736.md) | ⭐⭐ | M | [YAML](../data/tt3736_ltc_gen.yaml) | [SVG](../../waveforms/tt3736_ltc_gen.svg) | [Project 3736](https://app.tinytapeout.com/projects/3736) |
+| [miniMAC](tt3758.md) | ⭐⭐ | M | [YAML](../data/tt3758_minimac.yaml) | [SVG](../../waveforms/tt3758_ui_in.svg) | [Project 3758](https://app.tinytapeout.com/projects/3758) |
+| [test hard macro](tt3759.md) | ⭐⭐ | M | [YAML](../data/tt3759_adder4b.yaml) | [SVG](../../waveforms/tt3759_adder4b.svg) | [Project 3759](https://app.tinytapeout.com/projects/3759) |
+| [E-Beam Inspection Pixel Core](tt3765.md) | ⭐⭐ | M | [YAML](../data/tt3765_ebeam.yaml) | [SVG](../../waveforms/tt3765_ebeam.svg) | [Project 3765](https://app.tinytapeout.com/projects/3765) |
+| [Kalman Filter for IMU](tt3768.md) | ⭐⭐ | M | [YAML](../data/tt3768_kalman_filter.yaml) | [SVG](../../waveforms/tt3768_ui_in.svg) | [Project 3768](https://app.tinytapeout.com/projects/3768) |
+| [SEQ_MAC_INF_16H3 - Neural Network Inference Accelerator](tt3948.md) | ⭐⭐ | M | [YAML](../data/tt3948_seq_mac_inf.yaml) | [SVG](../../waveforms/tt3948_uio_in.svg) | [Project 3948](https://app.tinytapeout.com/projects/3948) |
+| [SIMON](tt3978.md) | ⭐⭐ | M | [YAML](../data/tt3978_simon.yaml) | [SVG](../../waveforms/tt3978_simon.svg) | [Project 3978](https://app.tinytapeout.com/projects/3978) |
+| [Custom coprocessor](tt4006.md) | ⭐⭐ | M | [YAML](../data/tt4006_coprocessor.yaml) | [SVG](../../waveforms/tt4006_uo_out.svg) | [Project 4006](https://app.tinytapeout.com/projects/4006) |
 | Plasma | ⭐⭐ | M | N/A | N/A | [Project 4048](https://app.tinytapeout.com/projects/4048) |
 | moss_display | ⭐⭐ | M | N/A | N/A | [Project 4050](https://app.tinytapeout.com/projects/4050) |
 | Tiny MMU | ⭐⭐ | M | N/A | N/A | [Project 4063](https://app.tinytapeout.com/projects/4063) |
 | Three Body Solution | ⭐⭐ | M | N/A | N/A | [Project 4071](https://app.tinytapeout.com/projects/4071) |
 | 8-bit RISC-V Lite CPU | ⭐⭐ | M | N/A | N/A | [Project 4076](https://app.tinytapeout.com/projects/4076) |
-| NYAN CAT | ⭐⭐ | M | [YAML](../data/tt4100_nyan_cat.yaml) | N/A | [Project 4100](https://app.tinytapeout.com/projects/4100) |
-| FIR Filter | ⭐ | S | [YAML](../data/tt3400_fir_filter.yaml) | [SVG](../../waveforms/tt3400_fir_filter.svg) | [Project 3400](https://app.tinytapeout.com/projects/3400) |
-| Verilog Multistage Oscillator with Enable and Counter | ⭐ | S | [YAML](../data/tt3404_oscillator.yaml) | [SVG](../../waveforms/tt3404_oscillator.svg) | [Project 3404](https://app.tinytapeout.com/projects/3404) |
-| xorshift | ⭐ | S | [YAML](../data/tt3409_xorshift.yaml) | [SVG](../../waveforms/tt3409_xorshift.svg) | [Project 3409](https://app.tinytapeout.com/projects/3409) |
-| Counter | ⭐ | S | [YAML](../data/tt3410_counter.yaml) | [SVG](../../waveforms/tt3410_uo_out.svg) | [Project 3410](https://app.tinytapeout.com/projects/3410) |
-| NCO | ⭐ | S | [YAML](../data/tt3417_nco.yaml) | [SVG](../../waveforms/tt3417_nco.svg) | [Project 3417](https://app.tinytapeout.com/projects/3417) |
-| Morse Code Detector (With Serial RX) | ⭐ | S | [YAML](../data/tt3422_morse_detector.yaml) | [SVG](../../waveforms/tt3422_morse_detector.svg) | [Project 3422](https://app.tinytapeout.com/projects/3422) |
-| Classic 8-bit era Programmable Sound Generator SN76489 | ⭐ | S | [YAML](../data/tt3430_sn76489.yaml) | [SVG](../../waveforms/tt3430_ui_in.svg) | [Project 3430](https://app.tinytapeout.com/projects/3430) |
-| Cell mux | ⭐ | S | [YAML](../data/tt3439_cell_mux.yaml) | [SVG](../../waveforms/tt3439_cell_mux.svg) | [Project 3439](https://app.tinytapeout.com/projects/3439) |
-| Zedulo TestChip1 | ⭐ | S | [YAML](../data/tt3440_zedtc1.yaml) | [SVG](../../waveforms/tt3440_ui_in.svg) | [Project 3440](https://app.tinytapeout.com/projects/3440) |
-| MarcoPolo | ⭐ | S | [YAML](../data/tt3454_marcopolo.yaml) | [SVG](../../waveforms/tt3454_marcopolo.svg) | [Project 3454](https://app.tinytapeout.com/projects/3454) |
-| Flame demo | ⭐ | S | [YAML](../data/tt3477_flame_demo.yaml) | [SVG](../../waveforms/tt3477_flame_demo.svg) | [Project 3477](https://app.tinytapeout.com/projects/3477) |
-| Chip ROM | ⭐ | S | [YAML](../data/tt3486_chip_rom.yaml) | [SVG](../../waveforms/tt3486_chip_rom.svg) | [Project 3486](https://app.tinytapeout.com/projects/3486) |
-| Tiny Tapeout Factory Test | ⭐ | S | [YAML](../data/tt3487_factory_test.yaml) | [SVG](../../waveforms/tt3487_factory_test.svg) | [Project 3487](https://app.tinytapeout.com/projects/3487) |
-| Universal Binary to Segment Decoder | ⭐ | S | [YAML](../data/tt3491_ubcd.yaml) | [SVG](../../waveforms/tt3491_uio_in.svg) | [Project 3491](https://app.tinytapeout.com/projects/3491) |
-| Hardware UTF Encoder/Decoder | ⭐ | S | [YAML](../data/tt3492_utf8.yaml) | [SVG](../../waveforms/tt3492_utf8.svg) | [Project 3492](https://app.tinytapeout.com/projects/3492) |
-| INTERCAL ALU | ⭐ | S | [YAML](../data/tt3493_intercal_alu.yaml) | [SVG](../../waveforms/tt3493_intercal_alu.svg) | [Project 3493](https://app.tinytapeout.com/projects/3493) |
-| Simon Says memory game | ⭐ | S | [YAML](../data/tt3495_simon.yaml) | [SVG](../../waveforms/tt3495_simon.svg) | [Project 3495](https://app.tinytapeout.com/projects/3495) |
-| Silicon Art - Pixel Pig + Canary Token | ⭐ | S | [YAML](../data/tt3497_art.yaml) | [SVG](../../waveforms/tt3497_ui_in.svg) | [Project 3497](https://app.tinytapeout.com/projects/3497) |
-| MBIST + MBISR Built-In Memory Test & Repair | ⭐ | S | [YAML](../data/tt3498_mbist.yaml) | [SVG](../../waveforms/tt3498_uo_out.svg) | [Project 3498](https://app.tinytapeout.com/projects/3498) |
-| RandomNum | ⭐ | S | [YAML](../data/tt3503_randomnum.yaml) | [SVG](../../waveforms/tt3503_ui_in.svg) | [Project 3503](https://app.tinytapeout.com/projects/3503) |
-| test | ⭐ | S | [YAML](../data/tt3504_test.yaml) | [SVG](../../waveforms/tt3504_ui_in.svg) | [Project 3504](https://app.tinytapeout.com/projects/3504) |
-| TinyTapeout test | ⭐ | S | [YAML](../data/tt3505_test.yaml) | [SVG](../../waveforms/tt3505_ui_in.svg) | [Project 3505](https://app.tinytapeout.com/projects/3505) |
-| Snake | ⭐ | S | [YAML](../data/tt3506_snake.yaml) | [SVG](../../waveforms/tt3506_snake.svg) | [Project 3506](https://app.tinytapeout.com/projects/3506) |
-| test_prj | ⭐ | S | [YAML](../data/tt3507_test_prj.yaml) | [SVG](../../waveforms/tt3507_test_prj.svg) | [Project 3507](https://app.tinytapeout.com/projects/3507) |
-| Tadder | ⭐ | S | [YAML](../data/tt3508_tadder.yaml) | [SVG](../../waveforms/tt3508_tadder.svg) | [Project 3508](https://app.tinytapeout.com/projects/3508) |
-| Silly Dog | ⭐ | S | [YAML](../data/tt3509_silly_dog.yaml) | [SVG](../../waveforms/tt3509_ui_in.svg) | [Project 3509](https://app.tinytapeout.com/projects/3509) |
-| Not a Dinosaur | ⭐ | S | [YAML](../data/tt3510_dino.yaml) | [SVG](../../waveforms/tt3510_dino.svg) | [Project 3510](https://app.tinytapeout.com/projects/3510) |
-| vga test project | ⭐ | S | [YAML](../data/tt3511_vga_test.yaml) | [SVG](../../waveforms/tt3511_uo_out.svg) | [Project 3511](https://app.tinytapeout.com/projects/3511) |
-| Silly Dog VGA | ⭐ | S | [YAML](../data/tt3512_vga.yaml) | [SVG](../../waveforms/tt3512_vga.svg) | [Project 3512](https://app.tinytapeout.com/projects/3512) |
-| Discrete-to-ASIC Delta-Sigma Acquisition System | ⭐ | S | [YAML](../data/tt3515_cic_filter.yaml) | [SVG](../../waveforms/tt3515_cic_filter.svg) | [Project 3515](https://app.tinytapeout.com/projects/3515) |
-| Quad SPI Aggregator | ⭐ | S | [YAML](../data/tt3519_spi_aggregator.yaml) | [SVG](../../waveforms/tt3519_uio_in.svg) | [Project 3519](https://app.tinytapeout.com/projects/3519) |
-| Tiny D-Cache | ⭐ | S | [YAML](../data/tt3522_dcache.yaml) | [SVG](../../waveforms/tt3522_dcache.svg) | [Project 3522](https://app.tinytapeout.com/projects/3522) |
-| Digital Lock with Easter Eggs | ⭐ | S | [YAML](../data/tt3524_digital_lock.yaml) | [SVG](../../waveforms/tt3524_digital_lock.svg) | [Project 3524](https://app.tinytapeout.com/projects/3524) |
-| tinyTapeVerilog_out | ⭐ | S | [YAML](../data/tt3526_counter.yaml) | [SVG](../../waveforms/tt3526_counter.svg) | [Project 3526](https://app.tinytapeout.com/projects/3526) |
-| TinyTapeOut_gate | ⭐ | S | [YAML](../data/tt3534_gate.yaml) | [SVG](../../waveforms/tt3534_gate.svg) | [Project 3534](https://app.tinytapeout.com/projects/3534) |
-| 6 Bit Roulette | ⭐ | S | [YAML](../data/tt3537_roulette.yaml) | [SVG](../../waveforms/tt3537_roulette.svg) | [Project 3537](https://app.tinytapeout.com/projects/3537) |
-| tinytapout_test | ⭐ | S | [YAML](../data/tt3538_tinytapout_test.yaml) | [SVG](../../waveforms/tt3538_tinytapout_test.svg) | [Project 3538](https://app.tinytapeout.com/projects/3538) |
-| secretNo | ⭐ | S | [YAML](../data/tt3539_secretno.yaml) | [SVG](../../waveforms/tt3539_secretno.svg) | [Project 3539](https://app.tinytapeout.com/projects/3539) |
-| My first Wokwi design | ⭐ | S | [YAML](../data/tt3540_wokwi.yaml) | [SVG](../../waveforms/tt3540_wokwi.svg) | [Project 3540](https://app.tinytapeout.com/projects/3540) |
-| tt3541-2bit-adder | ⭐ | S | [YAML](../data/tt3541_2bit_adder.yaml) | [SVG](../../waveforms/tt3541_2bit_adder.svg) | [Project 3541](https://app.tinytapeout.com/projects/3541) |
-| VGABlock | ⭐ | S | [YAML](../data/tt3542_vgablock.yaml) | [SVG](../../waveforms/tt3542_vgablock.svg) | [Project 3542](https://app.tinytapeout.com/projects/3542) |
-| Tiny Ape Out | ⭐ | S | [YAML](../data/tt3545_apeout.yaml) | [SVG](../../waveforms/tt3545_apeout.svg) | [Project 3545](https://app.tinytapeout.com/projects/3545) |
-| tt3546-counter | ⭐ | S | [YAML](../data/tt3546_counter.yaml) | [SVG](../../waveforms/tt3546_counter.svg) | [Project 3546](https://app.tinytapeout.com/projects/3546) |
-| tiny-tapeout-workshop-result | ⭐ | S | [YAML](../data/tt3547_workshop.yaml) | [SVG](../../waveforms/tt3547_workshop.svg) | [Project 3547](https://app.tinytapeout.com/projects/3547) |
-| Full Adder Test | ⭐ | S | [YAML](../data/tt3548_full_adder.yaml) | [SVG](../../waveforms/tt3548_full_adder.svg) | [Project 3548](https://app.tinytapeout.com/projects/3548) |
-| Tiny Triangle Rasterizer | ⭐ | S | [YAML](../data/tt3549_rasterizer.yaml) | [SVG](../../waveforms/tt3549_rasterizer.svg) | [Project 3549](https://app.tinytapeout.com/projects/3549) |
-| (Hexa)Decimal Counter | ⭐ | S | [YAML](../data/tt3550_counter.yaml) | [SVG](../../waveforms/tt3550_counter.svg) | [Project 3550](https://app.tinytapeout.com/projects/3550) |
-| Mein Hund Gniesbert (Adder for 3) | ⭐ | S | [YAML](../data/tt3551_gniesbert.yaml) | [SVG](../../waveforms/tt3551_gniesbert.svg) | [Project 3551](https://app.tinytapeout.com/projects/3551) |
-| Primitive clock divider | ⭐ | S | [YAML](../data/tt3552_clk_div.yaml) | [SVG](../../waveforms/tt3552_uo_out.svg) | [Project 3552](https://app.tinytapeout.com/projects/3552) |
-| adder | ⭐ | S | [YAML](../data/tt3553_adder.yaml) | [SVG](../../waveforms/tt3553_ui_in.svg) | [Project 3553](https://app.tinytapeout.com/projects/3553) |
-| 7-Segment-Wokwi-Design | ⭐ | S | [YAML](../data/tt3554_7seg_letter.yaml) | [SVG](../../waveforms/tt3554_7seg_letter.svg) | [Project 3554](https://app.tinytapeout.com/projects/3554) |
-| Second TT experiment | ⭐ | S | [YAML](../data/tt3555_experiment.yaml) | [SVG](../../waveforms/tt3555_experiment.svg) | [Project 3555](https://app.tinytapeout.com/projects/3555) |
-| Yturkeri_Mytinytapeout | ⭐ | S | [YAML](../data/tt3556_yturkeri.yaml) | [SVG](../../waveforms/tt3556_yturkeri.svg) | [Project 3556](https://app.tinytapeout.com/projects/3556) |
-| Clocked Full Adder | ⭐ | S | [YAML](../data/tt3557_clocked_adder.yaml) | [SVG](../../waveforms/tt3557_clocked_adder.svg) | [Project 3557](https://app.tinytapeout.com/projects/3557) |
-| Cool Stuff | ⭐ | S | [YAML](../data/tt3558_cool_stuff.yaml) | [SVG](../../waveforms/tt3558_ui_in.svg) | [Project 3558](https://app.tinytapeout.com/projects/3558) |
-| Just logic | ⭐ | S | [YAML](../data/tt3559_just_logic.yaml) | [SVG](../../waveforms/tt3559_uo_out.svg) | [Project 3559](https://app.tinytapeout.com/projects/3559) |
-| RGB PWM | ⭐ | S | [YAML](../data/tt3560_rgb_pwm.yaml) | [SVG](../../waveforms/tt3560_rgb_pwm.svg) | [Project 3560](https://app.tinytapeout.com/projects/3560) |
-| uCore | ⭐ | S | [YAML](../data/tt3561_ucore.yaml) | [SVG](../../waveforms/tt3561_ucore.svg) | [Project 3561](https://app.tinytapeout.com/projects/3561) |
-| 7-Segment Adder (0, 1, 2) | ⭐ | S | [YAML](../data/tt3562_title.yaml) | [SVG](../../waveforms/tt3562_title.svg) | [Project 3562](https://app.tinytapeout.com/projects/3562) |
-| RS Half adder | ⭐ | S | [YAML](../data/tt3563_rs_half_adder.yaml) | [SVG](../../waveforms/tt3563_rs_half_adder.svg) | [Project 3563](https://app.tinytapeout.com/projects/3563) |
-| tt3564-2bit-adder | ⭐ | S | [YAML](../data/tt3564_2bit_adder.yaml) | [SVG](../../waveforms/tt3564_2bit_adder.svg) | [Project 3564](https://app.tinytapeout.com/projects/3564) |
-| FH Joanneum TinyTapeout | ⭐ | S | [YAML](../data/tt3565_soc.yaml) | [SVG](../../waveforms/tt3565_soc.svg) | [Project 3565](https://app.tinytapeout.com/projects/3565) |
-| test (AND gate) | ⭐ | S | [YAML](../data/tt3566_test.yaml) | [SVG](../../waveforms/tt3566_ui_in.svg) | [Project 3566](https://app.tinytapeout.com/projects/3566) |
-| Inverter Template Test | ⭐ | S | [YAML](../data/tt3567_test.yaml) | [SVG](../../waveforms/tt3567_test.svg) | [Project 3567](https://app.tinytapeout.com/projects/3567) |
-| My first tapeout | ⭐ | S | [YAML](../data/tt3568_my_first_tapeout.yaml) | [SVG](../../waveforms/tt3568_my_first_tapeout.svg) | [Project 3568](https://app.tinytapeout.com/projects/3568) |
-| RTX 8090 | ⭐ | S | [YAML](../data/tt3569_rtx8090.yaml) | [SVG](../../waveforms/tt3569_rtx8090.svg) | [Project 3569](https://app.tinytapeout.com/projects/3569) |
-| Temporary Title | ⭐ | S | [YAML](../data/tt3570_temp_title.yaml) | [SVG](../../waveforms/tt3570_temp_title.svg) | [Project 3570](https://app.tinytapeout.com/projects/3570) |
-| Tiny Tapeout N | ⭐ | S | [YAML](../data/tt3571_toso.yaml) | [SVG](../../waveforms/tt3571_ui_in.svg) | [Project 3571](https://app.tinytapeout.com/projects/3571) |
-| Tiny Tapeout - Riddle Implementation | ⭐ | S | [YAML](../data/tt3572_riddle.yaml) | [SVG](../../waveforms/tt3572_riddle.svg) | [Project 3572](https://app.tinytapeout.com/projects/3572) |
-| Custom_ASIC | ⭐ | S | [YAML](../data/tt3573_custom_asic.yaml) | [SVG](../../waveforms/tt3573_custom_asic.svg) | [Project 3573](https://app.tinytapeout.com/projects/3573) |
-| Tudor BCD Test | ⭐ | S | [YAML](../data/tt3574_bcd.yaml) | [SVG](../../waveforms/tt3574_bcd.svg) | [Project 3574](https://app.tinytapeout.com/projects/3574) |
-| FirstTapeOut2 | ⭐ | S | [YAML](../data/tt3575_red_and.yaml) | [SVG](../../waveforms/tt3575_red_and.svg) | [Project 3575](https://app.tinytapeout.com/projects/3575) |
-| Tiny Tapeout Test | ⭐ | S | [YAML](../data/tt3576_test.yaml) | [SVG](../../waveforms/tt3576_uo_out.svg) | [Project 3576](https://app.tinytapeout.com/projects/3576) |
-| 18-bit Ripple Counter | ⭐ | S | [YAML](../data/tt3577_counter.yaml) | [SVG](../../waveforms/tt3577_counter.svg) | [Project 3577](https://app.tinytapeout.com/projects/3577) |
-| neb tt26a first asic | ⭐ | S | [YAML](../data/tt3578_neb_tt26a_first_asic.yaml) | [SVG](../../waveforms/tt3578_neb_tt26a_first_asic.svg) | [Project 3578](https://app.tinytapeout.com/projects/3578) |
-| Programmable 8-BIT CPU | ⭐ | S | [YAML](../data/tt3579_cpu.yaml) | [SVG](../../waveforms/tt3579_cpu.svg) | [Project 3579](https://app.tinytapeout.com/projects/3579) |
-| Try1 | ⭐ | S | [YAML](../data/tt3580_try1.yaml) | [SVG](../../waveforms/tt3580_try1.svg) | [Project 3580](https://app.tinytapeout.com/projects/3580) |
-| random stuff (NOT gates) | ⭐ | S | [YAML](../data/tt3581_random.yaml) | [SVG](../../waveforms/tt3581_uo_out.svg) | [Project 3581](https://app.tinytapeout.com/projects/3581) |
-| Invertors Class Template | ⭐ | S | [YAML](../data/tt3582_invertors.yaml) | [SVG](../../waveforms/tt3582_invertors.svg) | [Project 3582](https://app.tinytapeout.com/projects/3582) |
-| Tiny Tapeout | ⭐ | S | [YAML](../data/tt3584_test.yaml) | [SVG](../../waveforms/tt3584_test.svg) | [Project 3584](https://app.tinytapeout.com/projects/3584) |
-| Tiny Tapeout | ⭐ | S | [YAML](../data/tt3585_or_gates.yaml) | [SVG](../../waveforms/tt3585_or_gates.svg) | [Project 3585](https://app.tinytapeout.com/projects/3585) |
-| Clock Divider Test Project | ⭐ | S | [YAML](../data/tt3586_clk_div.yaml) | [SVG](../../waveforms/tt3586_ui_in.svg) | [Project 3586](https://app.tinytapeout.com/projects/3586) |
-| lriglooCs-first-Wokwi-design | ⭐ | S | [YAML](../data/tt3587_lriglooc.yaml) | [SVG](../../waveforms/tt3587_lriglooc.svg) | [Project 3587](https://app.tinytapeout.com/projects/3587) |
-| custom_lol | ⭐ | S | [YAML](../data/tt3588_custom_lol.yaml) | [SVG](../../waveforms/tt3588_custom_lol.svg) | [Project 3588](https://app.tinytapeout.com/projects/3588) |
-| 83rk: Tiny Tapeout | ⭐ | S | [YAML](../data/tt3589_sr_ff.yaml) | [SVG](../../waveforms/tt3589_uo_out.svg) | [Project 3589](https://app.tinytapeout.com/projects/3589) |
-| bad multiplexer | ⭐ | S | [YAML](../data/tt3590_bad_mux.yaml) | [SVG](../../waveforms/tt3590_bad_mux.svg) | [Project 3590](https://app.tinytapeout.com/projects/3590) |
-| Tiny Tapeout N | ⭐ | S | [YAML](../data/tt3591.yaml) | [SVG](../../waveforms/tt3591.svg) | [Project 3591](https://app.tinytapeout.com/projects/3591) |
-| 4-to-1 Multiplexer | ⭐ | S | [YAML](../data/tt3592_test.yaml) | [SVG](../../waveforms/tt3592_test.svg) | [Project 3592](https://app.tinytapeout.com/projects/3592) |
-| Workshop Day | ⭐ | S | [YAML](../data/tt3593_workshop_day.yaml) | [SVG](../../waveforms/tt3593_workshop_day.svg) | [Project 3593](https://app.tinytapeout.com/projects/3593) |
-| Test | ⭐ | S | [YAML](../data/tt3594_test.yaml) | [SVG](../../waveforms/tt3594_uo_out.svg) | [Project 3594](https://app.tinytapeout.com/projects/3594) |
-| Hello tinyTapout | ⭐ | S | [YAML](../data/tt3595_hello_tt.yaml) | [SVG](../../waveforms/tt3595_hello_tt.svg) | [Project 3595](https://app.tinytapeout.com/projects/3595) |
-| TinyTapeoutTestProject | ⭐ | S | [YAML](../data/tt3596.yaml) | [SVG](../../waveforms/tt3596.svg) | [Project 3596](https://app.tinytapeout.com/projects/3596) |
-| Apfelstrudel | ⭐ | S | [YAML](../data/tt3597_apfelstrudel.yaml) | [SVG](../../waveforms/tt3597_apfelstrudel.svg) | [Project 3597](https://app.tinytapeout.com/projects/3597) |
-| Freddys tapeout | ⭐ | S | [YAML](../data/tt3598_freddys_tapeout.yaml) | [SVG](../../waveforms/tt3598_freddys_tapeout.svg) | [Project 3598](https://app.tinytapeout.com/projects/3598) |
-| ^My first design | ⭐ | S | [YAML](../data/tt3599_first_design.yaml) | [SVG](../../waveforms/tt3599_ui_in.svg) | [Project 3599](https://app.tinytapeout.com/projects/3599) |
-| Simon Says | ⭐ | S | [YAML](../data/tt3600_serializer.yaml) | [SVG](../../waveforms/tt3600_serializer.svg) | [Project 3600](https://app.tinytapeout.com/projects/3600) |
-| just copy 4 not gates | ⭐ | S | [YAML](../data/tt3601.yaml) | [SVG](../../waveforms/tt3601.svg) | [Project 3601](https://app.tinytapeout.com/projects/3601) |
-| Flip-Flop Test | ⭐ | S | [YAML](../data/tt3602_test.yaml) | [SVG](../../waveforms/tt3602_test.svg) | [Project 3602](https://app.tinytapeout.com/projects/3602) |
-| TinyTapeout logic gate test | ⭐ | S | [YAML](../data/tt3603_gates.yaml) | [SVG](../../waveforms/tt3603_gates.svg) | [Project 3603](https://app.tinytapeout.com/projects/3603) |
-| Tobias first Wokwi design | ⭐ | S | [YAML](../data/tt3604_tobias.yaml) | [SVG](../../waveforms/tt3604_uo_out.svg) | [Project 3604](https://app.tinytapeout.com/projects/3604) |
-| DDMTD | ⭐ | S | [YAML](../data/tt3605_ddmtd.yaml) | [SVG](../../waveforms/tt3605_ddmtd.svg) | [Project 3605](https://app.tinytapeout.com/projects/3605) |
-| Tiny Tapeout Accumulator | ⭐ | S | [YAML](../data/tt3606.yaml) | [SVG](../../waveforms/tt3606.svg) | [Project 3606](https://app.tinytapeout.com/projects/3606) |
-| Switch Puzzle Logic | ⭐ | S | [YAML](../data/tt3607_puzzle.yaml) | [SVG](../../waveforms/tt3607_puzzle.svg) | [Project 3607](https://app.tinytapeout.com/projects/3607) |
-| Full Adder (Doom?) | ⭐ | S | [YAML](../data/tt3608_full_adder.yaml) | [SVG](../../waveforms/tt3608_full_adder.svg) | [Project 3608](https://app.tinytapeout.com/projects/3608) |
-| tinytapeout | ⭐ | S | [YAML](../data/tt3609_tinytapeout.yaml) | [SVG](../../waveforms/tt3609_tinytapeout.svg) | [Project 3609](https://app.tinytapeout.com/projects/3609) |
-| Test | ⭐ | S | [YAML](../data/tt3610_test.yaml) | [SVG](../../waveforms/tt3610_test.svg) | [Project 3610](https://app.tinytapeout.com/projects/3610) |
-| Count Upwards (7-segment) | ⭐ | S | [YAML](../data/tt3611_counter.yaml) | [SVG](../../waveforms/tt3611_counter.svg) | [Project 3611](https://app.tinytapeout.com/projects/3611) |
-| 6-bit Ring Register | ⭐ | S | [YAML](../data/tt3612_shift.yaml) | [SVG](../../waveforms/tt3612_shift.svg) | [Project 3612](https://app.tinytapeout.com/projects/3612) |
-| Nielss first failure | ⭐ | S | [YAML](../data/tt3613_nielss_first_failure.yaml) | [SVG](../../waveforms/tt3613_nielss_first_failure.svg) | [Project 3613](https://app.tinytapeout.com/projects/3613) |
-| 1-bit Full Adder | ⭐ | S | [YAML](../data/tt3614_full_adder.yaml) | [SVG](../../waveforms/tt3614_full_adder.svg) | [Project 3614](https://app.tinytapeout.com/projects/3614) |
-| gatekeeping the gates | ⭐ | S | [YAML](../data/tt3615_gates.yaml) | [SVG](../../waveforms/tt3615_gates.svg) | [Project 3615](https://app.tinytapeout.com/projects/3615) |
-| Two Song Buzzer Player | ⭐ | S | [YAML](../data/tt3616_buzzer.yaml) | [SVG](../../waveforms/tt3616_buzzer.svg) | [Project 3616](https://app.tinytapeout.com/projects/3616) |
-| 6-bit Ring Register WIP | ⭐ | S | [YAML](../data/tt3617_wip.yaml) | [SVG](../../waveforms/tt3617_wip.svg) | [Project 3617](https://app.tinytapeout.com/projects/3617) |
-| tt-verilog | ⭐ | S | [YAML](../data/tt3618_verilog.yaml) | [SVG](../../waveforms/tt3618_verilog.svg) | [Project 3618](https://app.tinytapeout.com/projects/3618) |
-| Tiny_Tapeout_Test | ⭐ | S | [YAML](../data/tt3619_test.yaml) | [SVG](../../waveforms/tt3619_test.svg) | [Project 3619](https://app.tinytapeout.com/projects/3619) |
-| Test | ⭐ | S | [YAML](../data/tt3620_test.yaml) | [SVG](../../waveforms/tt3620_test.svg) | [Project 3620](https://app.tinytapeout.com/projects/3620) |
-| WIP 7-seg Spinner | ⭐ | S | [YAML](../data/tt3622_wip.yaml) | [SVG](../../waveforms/tt3622_wip.svg) | [Project 3622](https://app.tinytapeout.com/projects/3622) |
-| little frequency divider | ⭐ | S | [YAML](../data/tt3623_freq_divider.yaml) | [SVG](../../waveforms/tt3623_freq_divider.svg) | [Project 3623](https://app.tinytapeout.com/projects/3623) |
-| Tiny Tapeout 1 | ⭐ | S | [YAML](../data/tt3624_nn_test.yaml) | [SVG](../../waveforms/tt3624_ui_in.svg) | [Project 3624](https://app.tinytapeout.com/projects/3624) |
-| 74LS138 (Inverter + Pass-through) | ⭐ | S | [YAML](../data/tt3625_74ls138.yaml) | [SVG](../../waveforms/tt3625_74ls138.svg) | [Project 3625](https://app.tinytapeout.com/projects/3625) |
-| Test - shift register | ⭐ | S | [YAML](../data/tt3626_shift_reg.yaml) | [SVG](../../waveforms/tt3626_ui_in.svg) | [Project 3626](https://app.tinytapeout.com/projects/3626) |
-| DR Flip-flop Counter | ⭐ | S | [YAML](../data/tt3627_counter.yaml) | [SVG](../../waveforms/tt3627_counter.svg) | [Project 3627](https://app.tinytapeout.com/projects/3627) |
-| WIP (Logic & Pass-through) | ⭐ | S | [YAML](../data/tt3629_wip.yaml) | [SVG](../../waveforms/tt3629_wip.svg) | [Project 3629](https://app.tinytapeout.com/projects/3629) |
-| VGA demo | ⭐ | S | [YAML](../data/tt3630_vga.yaml) | [SVG](../../waveforms/tt3630_vga.svg) | [Project 3630](https://app.tinytapeout.com/projects/3630) |
-| VGA Squares | ⭐ | S | [YAML](../data/tt3632_vga_squares.yaml) | [SVG](../../waveforms/tt3632_vga_squares.svg) | [Project 3632](https://app.tinytapeout.com/projects/3632) |
-| VGA Maze Runner | ⭐ | S | [YAML](../data/tt3633_vga_maze_runner.yaml) | [SVG](../../waveforms/tt3633_ui_in.svg) | [Project 3633](https://app.tinytapeout.com/projects/3633) |
-| Yet another VGA tinytapeout | ⭐ | S | [YAML](../data/tt3638_vga.yaml) | [SVG](../../waveforms/tt3638_vga.svg) | [Project 3638](https://app.tinytapeout.com/projects/3638) |
-| VGA Rings | ⭐ | S | [YAML](../data/tt3640_vga_rings.yaml) | [SVG](../../waveforms/tt3640_vga_rings.svg) | [Project 3640](https://app.tinytapeout.com/projects/3640) |
-| 4-bit Counter | ⭐ | S | [YAML](../data/tt3646_counter.yaml) | [SVG](../../waveforms/tt3646_uo_out.svg) | [Project 3646](https://app.tinytapeout.com/projects/3646) |
-| Cyber EMBEDDEDINN | ⭐ | S | [YAML](../data/tt3650_vga_cyber.yaml) | [SVG](../../waveforms/tt3650_vga_cyber.svg) | [Project 3650](https://app.tinytapeout.com/projects/3650) |
-| Silly demo | ⭐ | S | [YAML](../data/tt3651_silly_demo.yaml) | [SVG](../../waveforms/tt3651_silly_demo.svg) | [Project 3651](https://app.tinytapeout.com/projects/3651) |
-| Chisel Async Test | ⭐ | S | [YAML](../data/tt3656.yaml) | [SVG](../../waveforms/tt3656.svg) | [Project 3656](https://app.tinytapeout.com/projects/3656) |
-| tt3657-4bit-adder | ⭐ | S | [YAML](../data/tt3657_4bit_adder.yaml) | [SVG](../../waveforms/tt3657_4bit_adder.svg) | [Project 3657](https://app.tinytapeout.com/projects/3657) |
-| Johnson counter | ⭐ | S | [YAML](../data/tt3663_johnson_counter.yaml) | [SVG](../../waveforms/tt3663_johnson_counter.svg) | [Project 3663](https://app.tinytapeout.com/projects/3663) |
-| Glitcher (Pulse Generator) | ⭐ | S | [YAML](../data/tt3664_glitcher.yaml) | [SVG](../../waveforms/tt3664_glitcher.svg) | [Project 3664](https://app.tinytapeout.com/projects/3664) |
-| TeenySPU | ⭐ | S | [YAML](../data/tt3665_teenyspu.yaml) | [SVG](../../waveforms/tt3665_teenyspu.svg) | [Project 3665](https://app.tinytapeout.com/projects/3665) |
-| Moving Average Filter | ⭐ | S | [YAML](../data/tt3666_dsp.yaml) | [SVG](../../waveforms/tt3666_dsp.svg) | [Project 3666](https://app.tinytapeout.com/projects/3666) |
-| 8Bit Posit MAC Unit | ⭐ | S | [YAML](../data/tt3667_posit_mac.yaml) | [SVG](../../waveforms/tt3667_posit_mac.svg) | [Project 3667](https://app.tinytapeout.com/projects/3667) |
-| Tiny tapeout and gate test | ⭐ | S | [YAML](../data/tt3668_and_gate.yaml) | [SVG](../../waveforms/tt3668_uo_out.svg) | [Project 3668](https://app.tinytapeout.com/projects/3668) |
-| Tiny Perceptron (Branch Predictor) | ⭐ | S | [YAML](../data/tt3669_tiny_perceptron.yaml) | [SVG](../../waveforms/tt3669_tiny_perceptron.svg) | [Project 3669](https://app.tinytapeout.com/projects/3669) |
-| Full Adder | ⭐ | S | [YAML](../data/tt3670_full_adder.yaml) | [SVG](../../waveforms/tt3670_full_adder.svg) | [Project 3670](https://app.tinytapeout.com/projects/3670) |
-| Test (AND gate) | ⭐ | S | [YAML](../data/tt3671_test.yaml) | [SVG](../../waveforms/tt3671_test.svg) | [Project 3671](https://app.tinytapeout.com/projects/3671) |
-| tt3674-7seg-binary | ⭐ | S | [YAML](../data/tt3674_7seg_binary.yaml) | [SVG](../../waveforms/tt3674_7seg_binary.svg) | [Project 3674](https://app.tinytapeout.com/projects/3674) |
-| SPI and I2C Register Bank | ⭐ | S | [YAML](../data/tt3675_reg_bank.yaml) | [SVG](../../waveforms/tt3675_reg_bank.svg) | [Project 3675](https://app.tinytapeout.com/projects/3675) |
-| Counter Circuit | ⭐ | S | [YAML](../data/tt3676_counter.yaml) | [SVG](../../waveforms/tt3676_counter.svg) | [Project 3676](https://app.tinytapeout.com/projects/3676) |
-| 2 Digit Display | ⭐ | S | [YAML](../data/tt3678_2_digit_display.yaml) | [SVG](../../waveforms/tt3678_ui_in.svg) | [Project 3678](https://app.tinytapeout.com/projects/3678) |
-| Full Adder | ⭐ | S | [YAML](../data/tt3679_full_adder.yaml) | [SVG](../../waveforms/tt3679_full_adder.svg) | [Project 3679](https://app.tinytapeout.com/projects/3679) |
-| nand_gate | ⭐ | S | [YAML](../data/tt3680_nand.yaml) | [SVG](../../waveforms/tt3680_nand.svg) | [Project 3680](https://app.tinytapeout.com/projects/3680) |
-| MJ Wokwi project (Full Adder) | ⭐ | S | [YAML](../data/tt3681_full_adder.yaml) | [SVG](../../waveforms/tt3681_full_adder.svg) | [Project 3681](https://app.tinytapeout.com/projects/3681) |
-| I2C to SPI Bridge | ⭐ | S | [YAML](../data/tt3682_bridge.yaml) | [SVG](../../waveforms/tt3682_bridge.svg) | [Project 3682](https://app.tinytapeout.com/projects/3682) |
+| [NYAN CAT](tt4100.md) | ⭐⭐ | M | [YAML](../data/tt4100_nyan_cat.yaml) | N/A | [Project 4100](https://app.tinytapeout.com/projects/4100) |
+| [FIR Filter](tt3400.md) | ⭐ | S | [YAML](../data/tt3400_fir_filter.yaml) | [SVG](../../waveforms/tt3400_fir_filter.svg) | [Project 3400](https://app.tinytapeout.com/projects/3400) |
+| [Verilog Multistage Oscillator with Enable and Counter](tt3404.md) | ⭐ | S | [YAML](../data/tt3404_oscillator.yaml) | [SVG](../../waveforms/tt3404_oscillator.svg) | [Project 3404](https://app.tinytapeout.com/projects/3404) |
+| [xorshift](tt3409.md) | ⭐ | S | [YAML](../data/tt3409_xorshift.yaml) | [SVG](../../waveforms/tt3409_xorshift.svg) | [Project 3409](https://app.tinytapeout.com/projects/3409) |
+| [Counter](tt3410.md) | ⭐ | S | [YAML](../data/tt3410_counter.yaml) | [SVG](../../waveforms/tt3410_uo_out.svg) | [Project 3410](https://app.tinytapeout.com/projects/3410) |
+| [NCO](tt3417.md) | ⭐ | S | [YAML](../data/tt3417_nco.yaml) | [SVG](../../waveforms/tt3417_nco.svg) | [Project 3417](https://app.tinytapeout.com/projects/3417) |
+| [Morse Code Detector (With Serial RX)](tt3422.md) | ⭐ | S | [YAML](../data/tt3422_morse_detector.yaml) | [SVG](../../waveforms/tt3422_morse_detector.svg) | [Project 3422](https://app.tinytapeout.com/projects/3422) |
+| [Classic 8-bit era Programmable Sound Generator SN76489](tt3430.md) | ⭐ | S | [YAML](../data/tt3430_sn76489.yaml) | [SVG](../../waveforms/tt3430_ui_in.svg) | [Project 3430](https://app.tinytapeout.com/projects/3430) |
+| [Cell mux](tt3439.md) | ⭐ | S | [YAML](../data/tt3439_cell_mux.yaml) | [SVG](../../waveforms/tt3439_cell_mux.svg) | [Project 3439](https://app.tinytapeout.com/projects/3439) |
+| [Zedulo TestChip1](tt3440.md) | ⭐ | S | [YAML](../data/tt3440_zedtc1.yaml) | [SVG](../../waveforms/tt3440_ui_in.svg) | [Project 3440](https://app.tinytapeout.com/projects/3440) |
+| [MarcoPolo](tt3454.md) | ⭐ | S | [YAML](../data/tt3454_marcopolo.yaml) | [SVG](../../waveforms/tt3454_marcopolo.svg) | [Project 3454](https://app.tinytapeout.com/projects/3454) |
+| [Flame demo](tt3477.md) | ⭐ | S | [YAML](../data/tt3477_flame_demo.yaml) | [SVG](../../waveforms/tt3477_flame_demo.svg) | [Project 3477](https://app.tinytapeout.com/projects/3477) |
+| [Chip ROM](tt3486.md) | ⭐ | S | [YAML](../data/tt3486_chip_rom.yaml) | [SVG](../../waveforms/tt3486_chip_rom.svg) | [Project 3486](https://app.tinytapeout.com/projects/3486) |
+| [Tiny Tapeout Factory Test](tt3487.md) | ⭐ | S | [YAML](../data/tt3487_factory_test.yaml) | [SVG](../../waveforms/tt3487_factory_test.svg) | [Project 3487](https://app.tinytapeout.com/projects/3487) |
+| [Universal Binary to Segment Decoder](tt3491.md) | ⭐ | S | [YAML](../data/tt3491_ubcd.yaml) | [SVG](../../waveforms/tt3491_uio_in.svg) | [Project 3491](https://app.tinytapeout.com/projects/3491) |
+| [Hardware UTF Encoder/Decoder](tt3492.md) | ⭐ | S | [YAML](../data/tt3492_utf8.yaml) | [SVG](../../waveforms/tt3492_utf8.svg) | [Project 3492](https://app.tinytapeout.com/projects/3492) |
+| [INTERCAL ALU](tt3493.md) | ⭐ | S | [YAML](../data/tt3493_intercal_alu.yaml) | [SVG](../../waveforms/tt3493_intercal_alu.svg) | [Project 3493](https://app.tinytapeout.com/projects/3493) |
+| [Simon Says memory game](tt3495.md) | ⭐ | S | [YAML](../data/tt3495_simon.yaml) | [SVG](../../waveforms/tt3495_simon.svg) | [Project 3495](https://app.tinytapeout.com/projects/3495) |
+| [Silicon Art - Pixel Pig + Canary Token](tt3497.md) | ⭐ | S | [YAML](../data/tt3497_art.yaml) | [SVG](../../waveforms/tt3497_ui_in.svg) | [Project 3497](https://app.tinytapeout.com/projects/3497) |
+| [MBIST + MBISR Built-In Memory Test & Repair](tt3498.md) | ⭐ | S | [YAML](../data/tt3498_mbist.yaml) | [SVG](../../waveforms/tt3498_uo_out.svg) | [Project 3498](https://app.tinytapeout.com/projects/3498) |
+| [RandomNum](tt3503.md) | ⭐ | S | [YAML](../data/tt3503_randomnum.yaml) | [SVG](../../waveforms/tt3503_ui_in.svg) | [Project 3503](https://app.tinytapeout.com/projects/3503) |
+| [test](tt3504.md) | ⭐ | S | [YAML](../data/tt3504_test.yaml) | [SVG](../../waveforms/tt3504_ui_in.svg) | [Project 3504](https://app.tinytapeout.com/projects/3504) |
+| [TinyTapeout test](tt3505.md) | ⭐ | S | [YAML](../data/tt3505_test.yaml) | [SVG](../../waveforms/tt3505_ui_in.svg) | [Project 3505](https://app.tinytapeout.com/projects/3505) |
+| [Snake](tt3506.md) | ⭐ | S | [YAML](../data/tt3506_snake.yaml) | [SVG](../../waveforms/tt3506_snake.svg) | [Project 3506](https://app.tinytapeout.com/projects/3506) |
+| [test_prj](tt3507.md) | ⭐ | S | [YAML](../data/tt3507_test_prj.yaml) | [SVG](../../waveforms/tt3507_test_prj.svg) | [Project 3507](https://app.tinytapeout.com/projects/3507) |
+| [Tadder](tt3508.md) | ⭐ | S | [YAML](../data/tt3508_tadder.yaml) | [SVG](../../waveforms/tt3508_tadder.svg) | [Project 3508](https://app.tinytapeout.com/projects/3508) |
+| [Silly Dog](tt3509.md) | ⭐ | S | [YAML](../data/tt3509_silly_dog.yaml) | [SVG](../../waveforms/tt3509_ui_in.svg) | [Project 3509](https://app.tinytapeout.com/projects/3509) |
+| [Not a Dinosaur](tt3510.md) | ⭐ | S | [YAML](../data/tt3510_dino.yaml) | [SVG](../../waveforms/tt3510_dino.svg) | [Project 3510](https://app.tinytapeout.com/projects/3510) |
+| [vga test project](tt3511.md) | ⭐ | S | [YAML](../data/tt3511_vga_test.yaml) | [SVG](../../waveforms/tt3511_uo_out.svg) | [Project 3511](https://app.tinytapeout.com/projects/3511) |
+| [Silly Dog VGA](tt3512.md) | ⭐ | S | [YAML](../data/tt3512_vga.yaml) | [SVG](../../waveforms/tt3512_vga.svg) | [Project 3512](https://app.tinytapeout.com/projects/3512) |
+| [Discrete-to-ASIC Delta-Sigma Acquisition System](tt3515.md) | ⭐ | S | [YAML](../data/tt3515_cic_filter.yaml) | [SVG](../../waveforms/tt3515_cic_filter.svg) | [Project 3515](https://app.tinytapeout.com/projects/3515) |
+| [Quad SPI Aggregator](tt3519.md) | ⭐ | S | [YAML](../data/tt3519_spi_aggregator.yaml) | [SVG](../../waveforms/tt3519_uio_in.svg) | [Project 3519](https://app.tinytapeout.com/projects/3519) |
+| [Tiny D-Cache](tt3522.md) | ⭐ | S | [YAML](../data/tt3522_dcache.yaml) | [SVG](../../waveforms/tt3522_dcache.svg) | [Project 3522](https://app.tinytapeout.com/projects/3522) |
+| [Digital Lock with Easter Eggs](tt3524.md) | ⭐ | S | [YAML](../data/tt3524_digital_lock.yaml) | [SVG](../../waveforms/tt3524_digital_lock.svg) | [Project 3524](https://app.tinytapeout.com/projects/3524) |
+| [tinyTapeVerilog_out](tt3526.md) | ⭐ | S | [YAML](../data/tt3526_counter.yaml) | [SVG](../../waveforms/tt3526_counter.svg) | [Project 3526](https://app.tinytapeout.com/projects/3526) |
+| [TinyTapeOut_gate](tt3534.md) | ⭐ | S | [YAML](../data/tt3534_gate.yaml) | [SVG](../../waveforms/tt3534_gate.svg) | [Project 3534](https://app.tinytapeout.com/projects/3534) |
+| [6 Bit Roulette](tt3537.md) | ⭐ | S | [YAML](../data/tt3537_roulette.yaml) | [SVG](../../waveforms/tt3537_roulette.svg) | [Project 3537](https://app.tinytapeout.com/projects/3537) |
+| [tinytapout_test](tt3538.md) | ⭐ | S | [YAML](../data/tt3538_tinytapout_test.yaml) | [SVG](../../waveforms/tt3538_tinytapout_test.svg) | [Project 3538](https://app.tinytapeout.com/projects/3538) |
+| [secretNo](tt3539.md) | ⭐ | S | [YAML](../data/tt3539_secretno.yaml) | [SVG](../../waveforms/tt3539_secretno.svg) | [Project 3539](https://app.tinytapeout.com/projects/3539) |
+| [My first Wokwi design](tt3540.md) | ⭐ | S | [YAML](../data/tt3540_wokwi.yaml) | [SVG](../../waveforms/tt3540_wokwi.svg) | [Project 3540](https://app.tinytapeout.com/projects/3540) |
+| [tt3541-2bit-adder](tt3541.md) | ⭐ | S | [YAML](../data/tt3541_2bit_adder.yaml) | [SVG](../../waveforms/tt3541_2bit_adder.svg) | [Project 3541](https://app.tinytapeout.com/projects/3541) |
+| [VGABlock](tt3542.md) | ⭐ | S | [YAML](../data/tt3542_vgablock.yaml) | [SVG](../../waveforms/tt3542_vgablock.svg) | [Project 3542](https://app.tinytapeout.com/projects/3542) |
+| [Tiny Ape Out](tt3545.md) | ⭐ | S | [YAML](../data/tt3545_apeout.yaml) | [SVG](../../waveforms/tt3545_apeout.svg) | [Project 3545](https://app.tinytapeout.com/projects/3545) |
+| [tt3546-counter](tt3546.md) | ⭐ | S | [YAML](../data/tt3546_counter.yaml) | [SVG](../../waveforms/tt3546_counter.svg) | [Project 3546](https://app.tinytapeout.com/projects/3546) |
+| [tiny-tapeout-workshop-result](tt3547.md) | ⭐ | S | [YAML](../data/tt3547_workshop.yaml) | [SVG](../../waveforms/tt3547_workshop.svg) | [Project 3547](https://app.tinytapeout.com/projects/3547) |
+| [Full Adder Test](tt3548.md) | ⭐ | S | [YAML](../data/tt3548_full_adder.yaml) | [SVG](../../waveforms/tt3548_full_adder.svg) | [Project 3548](https://app.tinytapeout.com/projects/3548) |
+| [Tiny Triangle Rasterizer](tt3549.md) | ⭐ | S | [YAML](../data/tt3549_rasterizer.yaml) | [SVG](../../waveforms/tt3549_rasterizer.svg) | [Project 3549](https://app.tinytapeout.com/projects/3549) |
+| [(Hexa)Decimal Counter](tt3550.md) | ⭐ | S | [YAML](../data/tt3550_counter.yaml) | [SVG](../../waveforms/tt3550_counter.svg) | [Project 3550](https://app.tinytapeout.com/projects/3550) |
+| [Mein Hund Gniesbert (Adder for 3)](tt3551.md) | ⭐ | S | [YAML](../data/tt3551_gniesbert.yaml) | [SVG](../../waveforms/tt3551_gniesbert.svg) | [Project 3551](https://app.tinytapeout.com/projects/3551) |
+| [Primitive clock divider](tt3552.md) | ⭐ | S | [YAML](../data/tt3552_clk_div.yaml) | [SVG](../../waveforms/tt3552_uo_out.svg) | [Project 3552](https://app.tinytapeout.com/projects/3552) |
+| [adder](tt3553.md) | ⭐ | S | [YAML](../data/tt3553_adder.yaml) | [SVG](../../waveforms/tt3553_ui_in.svg) | [Project 3553](https://app.tinytapeout.com/projects/3553) |
+| [7-Segment-Wokwi-Design](tt3554.md) | ⭐ | S | [YAML](../data/tt3554_7seg_letter.yaml) | [SVG](../../waveforms/tt3554_7seg_letter.svg) | [Project 3554](https://app.tinytapeout.com/projects/3554) |
+| [Second TT experiment](tt3555.md) | ⭐ | S | [YAML](../data/tt3555_experiment.yaml) | [SVG](../../waveforms/tt3555_experiment.svg) | [Project 3555](https://app.tinytapeout.com/projects/3555) |
+| [Yturkeri_Mytinytapeout](tt3556.md) | ⭐ | S | [YAML](../data/tt3556_yturkeri.yaml) | [SVG](../../waveforms/tt3556_yturkeri.svg) | [Project 3556](https://app.tinytapeout.com/projects/3556) |
+| [Clocked Full Adder](tt3557.md) | ⭐ | S | [YAML](../data/tt3557_clocked_adder.yaml) | [SVG](../../waveforms/tt3557_clocked_adder.svg) | [Project 3557](https://app.tinytapeout.com/projects/3557) |
+| [Cool Stuff](tt3558.md) | ⭐ | S | [YAML](../data/tt3558_cool_stuff.yaml) | [SVG](../../waveforms/tt3558_ui_in.svg) | [Project 3558](https://app.tinytapeout.com/projects/3558) |
+| [Just logic](tt3559.md) | ⭐ | S | [YAML](../data/tt3559_just_logic.yaml) | [SVG](../../waveforms/tt3559_uo_out.svg) | [Project 3559](https://app.tinytapeout.com/projects/3559) |
+| [RGB PWM](tt3560.md) | ⭐ | S | [YAML](../data/tt3560_rgb_pwm.yaml) | [SVG](../../waveforms/tt3560_rgb_pwm.svg) | [Project 3560](https://app.tinytapeout.com/projects/3560) |
+| [uCore](tt3561.md) | ⭐ | S | [YAML](../data/tt3561_ucore.yaml) | [SVG](../../waveforms/tt3561_ucore.svg) | [Project 3561](https://app.tinytapeout.com/projects/3561) |
+| [7-Segment Adder (0, 1, 2)](tt3562.md) | ⭐ | S | [YAML](../data/tt3562_title.yaml) | [SVG](../../waveforms/tt3562_title.svg) | [Project 3562](https://app.tinytapeout.com/projects/3562) |
+| [RS Half adder](tt3563.md) | ⭐ | S | [YAML](../data/tt3563_rs_half_adder.yaml) | [SVG](../../waveforms/tt3563_rs_half_adder.svg) | [Project 3563](https://app.tinytapeout.com/projects/3563) |
+| [tt3564-2bit-adder](tt3564.md) | ⭐ | S | [YAML](../data/tt3564_2bit_adder.yaml) | [SVG](../../waveforms/tt3564_2bit_adder.svg) | [Project 3564](https://app.tinytapeout.com/projects/3564) |
+| [FH Joanneum TinyTapeout](tt3565.md) | ⭐ | S | [YAML](../data/tt3565_soc.yaml) | [SVG](../../waveforms/tt3565_soc.svg) | [Project 3565](https://app.tinytapeout.com/projects/3565) |
+| [test (AND gate)](tt3566.md) | ⭐ | S | [YAML](../data/tt3566_test.yaml) | [SVG](../../waveforms/tt3566_ui_in.svg) | [Project 3566](https://app.tinytapeout.com/projects/3566) |
+| [Inverter Template Test](tt3567.md) | ⭐ | S | [YAML](../data/tt3567_test.yaml) | [SVG](../../waveforms/tt3567_test.svg) | [Project 3567](https://app.tinytapeout.com/projects/3567) |
+| [My first tapeout](tt3568.md) | ⭐ | S | [YAML](../data/tt3568_my_first_tapeout.yaml) | [SVG](../../waveforms/tt3568_my_first_tapeout.svg) | [Project 3568](https://app.tinytapeout.com/projects/3568) |
+| [RTX 8090](tt3569.md) | ⭐ | S | [YAML](../data/tt3569_rtx8090.yaml) | [SVG](../../waveforms/tt3569_rtx8090.svg) | [Project 3569](https://app.tinytapeout.com/projects/3569) |
+| [Temporary Title](tt3570.md) | ⭐ | S | [YAML](../data/tt3570_temp_title.yaml) | [SVG](../../waveforms/tt3570_temp_title.svg) | [Project 3570](https://app.tinytapeout.com/projects/3570) |
+| [Tiny Tapeout N](tt3571.md) | ⭐ | S | [YAML](../data/tt3571_toso.yaml) | [SVG](../../waveforms/tt3571_ui_in.svg) | [Project 3571](https://app.tinytapeout.com/projects/3571) |
+| [Tiny Tapeout - Riddle Implementation](tt3572.md) | ⭐ | S | [YAML](../data/tt3572_riddle.yaml) | [SVG](../../waveforms/tt3572_riddle.svg) | [Project 3572](https://app.tinytapeout.com/projects/3572) |
+| [Custom_ASIC](tt3573.md) | ⭐ | S | [YAML](../data/tt3573_custom_asic.yaml) | [SVG](../../waveforms/tt3573_custom_asic.svg) | [Project 3573](https://app.tinytapeout.com/projects/3573) |
+| [Tudor BCD Test](tt3574.md) | ⭐ | S | [YAML](../data/tt3574_bcd.yaml) | [SVG](../../waveforms/tt3574_bcd.svg) | [Project 3574](https://app.tinytapeout.com/projects/3574) |
+| [FirstTapeOut2](tt3575.md) | ⭐ | S | [YAML](../data/tt3575_red_and.yaml) | [SVG](../../waveforms/tt3575_red_and.svg) | [Project 3575](https://app.tinytapeout.com/projects/3575) |
+| [Tiny Tapeout Test](tt3576.md) | ⭐ | S | [YAML](../data/tt3576_test.yaml) | [SVG](../../waveforms/tt3576_uo_out.svg) | [Project 3576](https://app.tinytapeout.com/projects/3576) |
+| [18-bit Ripple Counter](tt3577.md) | ⭐ | S | [YAML](../data/tt3577_counter.yaml) | [SVG](../../waveforms/tt3577_counter.svg) | [Project 3577](https://app.tinytapeout.com/projects/3577) |
+| [neb tt26a first asic](tt3578.md) | ⭐ | S | [YAML](../data/tt3578_neb_tt26a_first_asic.yaml) | [SVG](../../waveforms/tt3578_neb_tt26a_first_asic.svg) | [Project 3578](https://app.tinytapeout.com/projects/3578) |
+| [Programmable 8-BIT CPU](tt3579.md) | ⭐ | S | [YAML](../data/tt3579_cpu.yaml) | [SVG](../../waveforms/tt3579_cpu.svg) | [Project 3579](https://app.tinytapeout.com/projects/3579) |
+| [Try1](tt3580.md) | ⭐ | S | [YAML](../data/tt3580_try1.yaml) | [SVG](../../waveforms/tt3580_try1.svg) | [Project 3580](https://app.tinytapeout.com/projects/3580) |
+| [random stuff (NOT gates)](tt3581.md) | ⭐ | S | [YAML](../data/tt3581_random.yaml) | [SVG](../../waveforms/tt3581_uo_out.svg) | [Project 3581](https://app.tinytapeout.com/projects/3581) |
+| [Invertors Class Template](tt3582.md) | ⭐ | S | [YAML](../data/tt3582_invertors.yaml) | [SVG](../../waveforms/tt3582_invertors.svg) | [Project 3582](https://app.tinytapeout.com/projects/3582) |
+| [Tiny Tapeout](tt3584.md) | ⭐ | S | [YAML](../data/tt3584_test.yaml) | [SVG](../../waveforms/tt3584_test.svg) | [Project 3584](https://app.tinytapeout.com/projects/3584) |
+| [Tiny Tapeout](tt3585.md) | ⭐ | S | [YAML](../data/tt3585_or_gates.yaml) | [SVG](../../waveforms/tt3585_or_gates.svg) | [Project 3585](https://app.tinytapeout.com/projects/3585) |
+| [Clock Divider Test Project](tt3586.md) | ⭐ | S | [YAML](../data/tt3586_clk_div.yaml) | [SVG](../../waveforms/tt3586_ui_in.svg) | [Project 3586](https://app.tinytapeout.com/projects/3586) |
+| [lriglooCs-first-Wokwi-design](tt3587.md) | ⭐ | S | [YAML](../data/tt3587_lriglooc.yaml) | [SVG](../../waveforms/tt3587_lriglooc.svg) | [Project 3587](https://app.tinytapeout.com/projects/3587) |
+| [custom_lol](tt3588.md) | ⭐ | S | [YAML](../data/tt3588_custom_lol.yaml) | [SVG](../../waveforms/tt3588_custom_lol.svg) | [Project 3588](https://app.tinytapeout.com/projects/3588) |
+| [83rk: Tiny Tapeout](tt3589.md) | ⭐ | S | [YAML](../data/tt3589_sr_ff.yaml) | [SVG](../../waveforms/tt3589_uo_out.svg) | [Project 3589](https://app.tinytapeout.com/projects/3589) |
+| [bad multiplexer](tt3590.md) | ⭐ | S | [YAML](../data/tt3590_bad_mux.yaml) | [SVG](../../waveforms/tt3590_bad_mux.svg) | [Project 3590](https://app.tinytapeout.com/projects/3590) |
+| [Tiny Tapeout N](tt3591.md) | ⭐ | S | [YAML](../data/tt3591.yaml) | [SVG](../../waveforms/tt3591.svg) | [Project 3591](https://app.tinytapeout.com/projects/3591) |
+| [4-to-1 Multiplexer](tt3592.md) | ⭐ | S | [YAML](../data/tt3592_test.yaml) | [SVG](../../waveforms/tt3592_test.svg) | [Project 3592](https://app.tinytapeout.com/projects/3592) |
+| [Workshop Day](tt3593.md) | ⭐ | S | [YAML](../data/tt3593_workshop_day.yaml) | [SVG](../../waveforms/tt3593_workshop_day.svg) | [Project 3593](https://app.tinytapeout.com/projects/3593) |
+| [Test](tt3594.md) | ⭐ | S | [YAML](../data/tt3594_test.yaml) | [SVG](../../waveforms/tt3594_uo_out.svg) | [Project 3594](https://app.tinytapeout.com/projects/3594) |
+| [Hello tinyTapout](tt3595.md) | ⭐ | S | [YAML](../data/tt3595_hello_tt.yaml) | [SVG](../../waveforms/tt3595_hello_tt.svg) | [Project 3595](https://app.tinytapeout.com/projects/3595) |
+| [TinyTapeoutTestProject](tt3596.md) | ⭐ | S | [YAML](../data/tt3596.yaml) | [SVG](../../waveforms/tt3596.svg) | [Project 3596](https://app.tinytapeout.com/projects/3596) |
+| [Apfelstrudel](tt3597.md) | ⭐ | S | [YAML](../data/tt3597_apfelstrudel.yaml) | [SVG](../../waveforms/tt3597_apfelstrudel.svg) | [Project 3597](https://app.tinytapeout.com/projects/3597) |
+| [Freddys tapeout](tt3598.md) | ⭐ | S | [YAML](../data/tt3598_freddys_tapeout.yaml) | [SVG](../../waveforms/tt3598_freddys_tapeout.svg) | [Project 3598](https://app.tinytapeout.com/projects/3598) |
+| [^My first design](tt3599.md) | ⭐ | S | [YAML](../data/tt3599_first_design.yaml) | [SVG](../../waveforms/tt3599_ui_in.svg) | [Project 3599](https://app.tinytapeout.com/projects/3599) |
+| [Simon Says](tt3600.md) | ⭐ | S | [YAML](../data/tt3600_serializer.yaml) | [SVG](../../waveforms/tt3600_serializer.svg) | [Project 3600](https://app.tinytapeout.com/projects/3600) |
+| [just copy 4 not gates](tt3601.md) | ⭐ | S | [YAML](../data/tt3601.yaml) | [SVG](../../waveforms/tt3601.svg) | [Project 3601](https://app.tinytapeout.com/projects/3601) |
+| [Flip-Flop Test](tt3602.md) | ⭐ | S | [YAML](../data/tt3602_test.yaml) | [SVG](../../waveforms/tt3602_test.svg) | [Project 3602](https://app.tinytapeout.com/projects/3602) |
+| [TinyTapeout logic gate test](tt3603.md) | ⭐ | S | [YAML](../data/tt3603_gates.yaml) | [SVG](../../waveforms/tt3603_gates.svg) | [Project 3603](https://app.tinytapeout.com/projects/3603) |
+| [Tobias first Wokwi design](tt3604.md) | ⭐ | S | [YAML](../data/tt3604_tobias.yaml) | [SVG](../../waveforms/tt3604_uo_out.svg) | [Project 3604](https://app.tinytapeout.com/projects/3604) |
+| [DDMTD](tt3605.md) | ⭐ | S | [YAML](../data/tt3605_ddmtd.yaml) | [SVG](../../waveforms/tt3605_ddmtd.svg) | [Project 3605](https://app.tinytapeout.com/projects/3605) |
+| [Tiny Tapeout Accumulator](tt3606.md) | ⭐ | S | [YAML](../data/tt3606.yaml) | [SVG](../../waveforms/tt3606.svg) | [Project 3606](https://app.tinytapeout.com/projects/3606) |
+| [Switch Puzzle Logic](tt3607.md) | ⭐ | S | [YAML](../data/tt3607_puzzle.yaml) | [SVG](../../waveforms/tt3607_puzzle.svg) | [Project 3607](https://app.tinytapeout.com/projects/3607) |
+| [Full Adder (Doom?)](tt3608.md) | ⭐ | S | [YAML](../data/tt3608_full_adder.yaml) | [SVG](../../waveforms/tt3608_full_adder.svg) | [Project 3608](https://app.tinytapeout.com/projects/3608) |
+| [tinytapeout](tt3609.md) | ⭐ | S | [YAML](../data/tt3609_tinytapeout.yaml) | [SVG](../../waveforms/tt3609_tinytapeout.svg) | [Project 3609](https://app.tinytapeout.com/projects/3609) |
+| [Test](tt3610.md) | ⭐ | S | [YAML](../data/tt3610_test.yaml) | [SVG](../../waveforms/tt3610_test.svg) | [Project 3610](https://app.tinytapeout.com/projects/3610) |
+| [Count Upwards (7-segment)](tt3611.md) | ⭐ | S | [YAML](../data/tt3611_counter.yaml) | [SVG](../../waveforms/tt3611_counter.svg) | [Project 3611](https://app.tinytapeout.com/projects/3611) |
+| [6-bit Ring Register](tt3612.md) | ⭐ | S | [YAML](../data/tt3612_shift.yaml) | [SVG](../../waveforms/tt3612_shift.svg) | [Project 3612](https://app.tinytapeout.com/projects/3612) |
+| [Nielss first failure](tt3613.md) | ⭐ | S | [YAML](../data/tt3613_nielss_first_failure.yaml) | [SVG](../../waveforms/tt3613_nielss_first_failure.svg) | [Project 3613](https://app.tinytapeout.com/projects/3613) |
+| [1-bit Full Adder](tt3614.md) | ⭐ | S | [YAML](../data/tt3614_full_adder.yaml) | [SVG](../../waveforms/tt3614_full_adder.svg) | [Project 3614](https://app.tinytapeout.com/projects/3614) |
+| [gatekeeping the gates](tt3615.md) | ⭐ | S | [YAML](../data/tt3615_gates.yaml) | [SVG](../../waveforms/tt3615_gates.svg) | [Project 3615](https://app.tinytapeout.com/projects/3615) |
+| [Two Song Buzzer Player](tt3616.md) | ⭐ | S | [YAML](../data/tt3616_buzzer.yaml) | [SVG](../../waveforms/tt3616_buzzer.svg) | [Project 3616](https://app.tinytapeout.com/projects/3616) |
+| [6-bit Ring Register WIP](tt3617.md) | ⭐ | S | [YAML](../data/tt3617_wip.yaml) | [SVG](../../waveforms/tt3617_wip.svg) | [Project 3617](https://app.tinytapeout.com/projects/3617) |
+| [tt-verilog](tt3618.md) | ⭐ | S | [YAML](../data/tt3618_verilog.yaml) | [SVG](../../waveforms/tt3618_verilog.svg) | [Project 3618](https://app.tinytapeout.com/projects/3618) |
+| [Tiny_Tapeout_Test](tt3619.md) | ⭐ | S | [YAML](../data/tt3619_test.yaml) | [SVG](../../waveforms/tt3619_test.svg) | [Project 3619](https://app.tinytapeout.com/projects/3619) |
+| [Test](tt3620.md) | ⭐ | S | [YAML](../data/tt3620_test.yaml) | [SVG](../../waveforms/tt3620_test.svg) | [Project 3620](https://app.tinytapeout.com/projects/3620) |
+| [WIP 7-seg Spinner](tt3622.md) | ⭐ | S | [YAML](../data/tt3622_wip.yaml) | [SVG](../../waveforms/tt3622_wip.svg) | [Project 3622](https://app.tinytapeout.com/projects/3622) |
+| [little frequency divider](tt3623.md) | ⭐ | S | [YAML](../data/tt3623_freq_divider.yaml) | [SVG](../../waveforms/tt3623_freq_divider.svg) | [Project 3623](https://app.tinytapeout.com/projects/3623) |
+| [Tiny Tapeout 1](tt3624.md) | ⭐ | S | [YAML](../data/tt3624_nn_test.yaml) | [SVG](../../waveforms/tt3624_ui_in.svg) | [Project 3624](https://app.tinytapeout.com/projects/3624) |
+| [74LS138 (Inverter + Pass-through)](tt3625.md) | ⭐ | S | [YAML](../data/tt3625_74ls138.yaml) | [SVG](../../waveforms/tt3625_74ls138.svg) | [Project 3625](https://app.tinytapeout.com/projects/3625) |
+| [Test - shift register](tt3626.md) | ⭐ | S | [YAML](../data/tt3626_shift_reg.yaml) | [SVG](../../waveforms/tt3626_ui_in.svg) | [Project 3626](https://app.tinytapeout.com/projects/3626) |
+| [DR Flip-flop Counter](tt3627.md) | ⭐ | S | [YAML](../data/tt3627_counter.yaml) | [SVG](../../waveforms/tt3627_counter.svg) | [Project 3627](https://app.tinytapeout.com/projects/3627) |
+| [WIP (Logic & Pass-through)](tt3629.md) | ⭐ | S | [YAML](../data/tt3629_wip.yaml) | [SVG](../../waveforms/tt3629_wip.svg) | [Project 3629](https://app.tinytapeout.com/projects/3629) |
+| [VGA demo](tt3630.md) | ⭐ | S | [YAML](../data/tt3630_vga.yaml) | [SVG](../../waveforms/tt3630_vga.svg) | [Project 3630](https://app.tinytapeout.com/projects/3630) |
+| [VGA Squares](tt3632.md) | ⭐ | S | [YAML](../data/tt3632_vga_squares.yaml) | [SVG](../../waveforms/tt3632_vga_squares.svg) | [Project 3632](https://app.tinytapeout.com/projects/3632) |
+| [VGA Maze Runner](tt3633.md) | ⭐ | S | [YAML](../data/tt3633_vga_maze_runner.yaml) | [SVG](../../waveforms/tt3633_ui_in.svg) | [Project 3633](https://app.tinytapeout.com/projects/3633) |
+| [Yet another VGA tinytapeout](tt3638.md) | ⭐ | S | [YAML](../data/tt3638_vga.yaml) | [SVG](../../waveforms/tt3638_vga.svg) | [Project 3638](https://app.tinytapeout.com/projects/3638) |
+| [VGA Rings](tt3640.md) | ⭐ | S | [YAML](../data/tt3640_vga_rings.yaml) | [SVG](../../waveforms/tt3640_vga_rings.svg) | [Project 3640](https://app.tinytapeout.com/projects/3640) |
+| [4-bit Counter](tt3646.md) | ⭐ | S | [YAML](../data/tt3646_counter.yaml) | [SVG](../../waveforms/tt3646_uo_out.svg) | [Project 3646](https://app.tinytapeout.com/projects/3646) |
+| [Cyber EMBEDDEDINN](tt3650.md) | ⭐ | S | [YAML](../data/tt3650_vga_cyber.yaml) | [SVG](../../waveforms/tt3650_vga_cyber.svg) | [Project 3650](https://app.tinytapeout.com/projects/3650) |
+| [Silly demo](tt3651.md) | ⭐ | S | [YAML](../data/tt3651_silly_demo.yaml) | [SVG](../../waveforms/tt3651_silly_demo.svg) | [Project 3651](https://app.tinytapeout.com/projects/3651) |
+| [Chisel Async Test](tt3656.md) | ⭐ | S | [YAML](../data/tt3656.yaml) | [SVG](../../waveforms/tt3656.svg) | [Project 3656](https://app.tinytapeout.com/projects/3656) |
+| [tt3657-4bit-adder](tt3657.md) | ⭐ | S | [YAML](../data/tt3657_4bit_adder.yaml) | [SVG](../../waveforms/tt3657_4bit_adder.svg) | [Project 3657](https://app.tinytapeout.com/projects/3657) |
+| [Johnson counter](tt3663.md) | ⭐ | S | [YAML](../data/tt3663_johnson_counter.yaml) | [SVG](../../waveforms/tt3663_johnson_counter.svg) | [Project 3663](https://app.tinytapeout.com/projects/3663) |
+| [Glitcher (Pulse Generator)](tt3664.md) | ⭐ | S | [YAML](../data/tt3664_glitcher.yaml) | [SVG](../../waveforms/tt3664_glitcher.svg) | [Project 3664](https://app.tinytapeout.com/projects/3664) |
+| [TeenySPU](tt3665.md) | ⭐ | S | [YAML](../data/tt3665_teenyspu.yaml) | [SVG](../../waveforms/tt3665_teenyspu.svg) | [Project 3665](https://app.tinytapeout.com/projects/3665) |
+| [Moving Average Filter](tt3666.md) | ⭐ | S | [YAML](../data/tt3666_dsp.yaml) | [SVG](../../waveforms/tt3666_dsp.svg) | [Project 3666](https://app.tinytapeout.com/projects/3666) |
+| [8Bit Posit MAC Unit](tt3667.md) | ⭐ | S | [YAML](../data/tt3667_posit_mac.yaml) | [SVG](../../waveforms/tt3667_posit_mac.svg) | [Project 3667](https://app.tinytapeout.com/projects/3667) |
+| [Tiny tapeout and gate test](tt3668.md) | ⭐ | S | [YAML](../data/tt3668_and_gate.yaml) | [SVG](../../waveforms/tt3668_uo_out.svg) | [Project 3668](https://app.tinytapeout.com/projects/3668) |
+| [Tiny Perceptron (Branch Predictor)](tt3669.md) | ⭐ | S | [YAML](../data/tt3669_tiny_perceptron.yaml) | [SVG](../../waveforms/tt3669_tiny_perceptron.svg) | [Project 3669](https://app.tinytapeout.com/projects/3669) |
+| [Full Adder](tt3670.md) | ⭐ | S | [YAML](../data/tt3670_full_adder.yaml) | [SVG](../../waveforms/tt3670_full_adder.svg) | [Project 3670](https://app.tinytapeout.com/projects/3670) |
+| [Test (AND gate)](tt3671.md) | ⭐ | S | [YAML](../data/tt3671_test.yaml) | [SVG](../../waveforms/tt3671_test.svg) | [Project 3671](https://app.tinytapeout.com/projects/3671) |
+| [tt3674-7seg-binary](tt3674.md) | ⭐ | S | [YAML](../data/tt3674_7seg_binary.yaml) | [SVG](../../waveforms/tt3674_7seg_binary.svg) | [Project 3674](https://app.tinytapeout.com/projects/3674) |
+| [SPI and I2C Register Bank](tt3675.md) | ⭐ | S | [YAML](../data/tt3675_reg_bank.yaml) | [SVG](../../waveforms/tt3675_reg_bank.svg) | [Project 3675](https://app.tinytapeout.com/projects/3675) |
+| [Counter Circuit](tt3676.md) | ⭐ | S | [YAML](../data/tt3676_counter.yaml) | [SVG](../../waveforms/tt3676_counter.svg) | [Project 3676](https://app.tinytapeout.com/projects/3676) |
+| [2 Digit Display](tt3678.md) | ⭐ | S | [YAML](../data/tt3678_2_digit_display.yaml) | [SVG](../../waveforms/tt3678_ui_in.svg) | [Project 3678](https://app.tinytapeout.com/projects/3678) |
+| [Full Adder](tt3679.md) | ⭐ | S | [YAML](../data/tt3679_full_adder.yaml) | [SVG](../../waveforms/tt3679_full_adder.svg) | [Project 3679](https://app.tinytapeout.com/projects/3679) |
+| [nand_gate](tt3680.md) | ⭐ | S | [YAML](../data/tt3680_nand.yaml) | [SVG](../../waveforms/tt3680_nand.svg) | [Project 3680](https://app.tinytapeout.com/projects/3680) |
+| [MJ Wokwi project (Full Adder)](tt3681.md) | ⭐ | S | [YAML](../data/tt3681_full_adder.yaml) | [SVG](../../waveforms/tt3681_full_adder.svg) | [Project 3681](https://app.tinytapeout.com/projects/3681) |
+| [I2C to SPI Bridge](tt3682.md) | ⭐ | S | [YAML](../data/tt3682_bridge.yaml) | [SVG](../../waveforms/tt3682_bridge.svg) | [Project 3682](https://app.tinytapeout.com/projects/3682) |
 | Tiny tape out test | ⭐ | S | N/A | N/A | [Project 3683](https://app.tinytapeout.com/projects/3683) |
-| 7 Segment BCD / CLA | ⭐ | S | [YAML](../data/tt3684_cla_bcd.yaml) | [SVG](../../waveforms/tt3684_cla_bcd.svg) | [Project 3684](https://app.tinytapeout.com/projects/3684) |
-| Paafus First Chip | ⭐ | S | [YAML](../data/tt3685_paafu.yaml) | [SVG](../../waveforms/tt3685_paafu.svg) | [Project 3685](https://app.tinytapeout.com/projects/3685) |
-| MyFirstChip (Patterns) | ⭐ | S | [YAML](../data/tt3686_chip.yaml) | [SVG](../../waveforms/tt3686_uo_out.svg) | [Project 3686](https://app.tinytapeout.com/projects/3686) |
-| Half Adder | ⭐ | S | [YAML](../data/tt3687_half_adder.yaml) | [SVG](../../waveforms/tt3687_half_adder.svg) | [Project 3687](https://app.tinytapeout.com/projects/3687) |
-| idk | ⭐ | S | [YAML](../data/tt3688_idk.yaml) | [SVG](../../waveforms/tt3688_ui_in.svg) | [Project 3688](https://app.tinytapeout.com/projects/3688) |
-| Simple Counter (Ripple Counter) | ⭐ | S | [YAML](../data/tt3689_simple_counter.yaml) | [SVG](../../waveforms/tt3689_simple_counter.svg) | [Project 3689](https://app.tinytapeout.com/projects/3689) |
-| Hello World (Logic gates) | ⭐ | S | [YAML](../data/tt3691_hello.yaml) | [SVG](../../waveforms/tt3691_hello.svg) | [Project 3691](https://app.tinytapeout.com/projects/3691) |
-| SPI RAM Driver | ⭐ | S | [YAML](../data/tt3692_spi_ram.yaml) | [SVG](../../waveforms/tt3692_spi_ram.svg) | [Project 3692](https://app.tinytapeout.com/projects/3692) |
-| TinyTapeNkTest | ⭐ | S | [YAML](../data/tt3693_tiny_tape_nk_test.yaml) | [SVG](../../waveforms/tt3693_uo_out.svg) | [Project 3693](https://app.tinytapeout.com/projects/3693) |
-| WIP Bin to Dec (OR Logic) | ⭐ | S | [YAML](../data/tt3694_bin2dec_wip.yaml) | [SVG](../../waveforms/tt3694_bin2dec_wip.svg) | [Project 3694](https://app.tinytapeout.com/projects/3694) |
-| Malthes First Template | ⭐ | S | [YAML](../data/tt3695_malthe.yaml) | [SVG](../../waveforms/tt3695_malthe.svg) | [Project 3695](https://app.tinytapeout.com/projects/3695) |
-| Alex first circuit (Johnson counter) | ⭐ | S | [YAML](../data/tt3696_circuit.yaml) | [SVG](../../waveforms/tt3696_circuit.svg) | [Project 3696](https://app.tinytapeout.com/projects/3696) |
-| GDS Test (Inverter + Pass-through) | ⭐ | S | [YAML](../data/tt3697_gds_test.yaml) | [SVG](../../waveforms/tt3697_gds_test.svg) | [Project 3697](https://app.tinytapeout.com/projects/3697) |
-| 4-bit full adder | ⭐ | S | [YAML](../data/tt3698_4_bit_full_adder.yaml) | [SVG](../../waveforms/tt3698_ui_in.svg) | [Project 3698](https://app.tinytapeout.com/projects/3698) |
-| Tiny Tapeout First Design (Logic Gates) | ⭐ | S | [YAML](../data/tt3699_first_design.yaml) | [SVG](../../waveforms/tt3699_first_design.svg) | [Project 3699](https://app.tinytapeout.com/projects/3699) |
-| One One | ⭐ | S | [YAML](../data/tt3700_one_one.yaml) | [SVG](../../waveforms/tt3700_one_one.svg) | [Project 3700](https://app.tinytapeout.com/projects/3700) |
-| Cremedelcreme | ⭐ | S | [YAML](../data/tt3701.yaml) | [SVG](../../waveforms/tt3701.svg) | [Project 3701](https://app.tinytapeout.com/projects/3701) |
-| Test Gates | ⭐ | S | [YAML](../data/tt3702_test_gates.yaml) | [SVG](../../waveforms/tt3702_test_gates.svg) | [Project 3702](https://app.tinytapeout.com/projects/3702) |
-| And_Or | ⭐ | S | [YAML](../data/tt3703_and_or.yaml) | [SVG](../../waveforms/tt3703_and_or.svg) | [Project 3703](https://app.tinytapeout.com/projects/3703) |
-| Hello GDS | ⭐ | S | [YAML](../data/tt3704_hello.yaml) | [SVG](../../waveforms/tt3704_hello.svg) | [Project 3704](https://app.tinytapeout.com/projects/3704) |
-| demo_chip | ⭐ | S | [YAML](../data/tt3705_demo_chip.yaml) | [SVG](../../waveforms/tt3705_demo_chip.svg) | [Project 3705](https://app.tinytapeout.com/projects/3705) |
-| Scott's first Wokwi design | ⭐ | S | [YAML](../data/tt3706.yaml) | [SVG](../../waveforms/tt3706.svg) | [Project 3706](https://app.tinytapeout.com/projects/3706) |
-| tinytapeout_henningp_2bin_to_4bit_decoder | ⭐ | S | [YAML](../data/tt3707_decoder.yaml) | [SVG](../../waveforms/tt3707_decoder.svg) | [Project 3707](https://app.tinytapeout.com/projects/3707) |
-| My first design | ⭐ | S | [YAML](../data/tt3708_my_first_design.yaml) | [SVG](../../waveforms/tt3708_my_first_design.svg) | [Project 3708](https://app.tinytapeout.com/projects/3708) |
-| TTIHP26a_Luke_Meta | ⭐ | S | [YAML](../data/tt3709_luke_meta.yaml) | [SVG](../../waveforms/tt3709_luke_meta.svg) | [Project 3709](https://app.tinytapeout.com/projects/3709) |
-| Undecided | ⭐ | S | [YAML](../data/tt3710_undecided.yaml) | [SVG](../../waveforms/tt3710_undecided.svg) | [Project 3710](https://app.tinytapeout.com/projects/3710) |
-| Tiny Tapeout Workshop Test (NAND) | ⭐ | S | [YAML](../data/tt3711_gates.yaml) | [SVG](../../waveforms/tt3711_uo_out.svg) | [Project 3711](https://app.tinytapeout.com/projects/3711) |
-| Amaury Basic Test | ⭐ | S | [YAML](../data/tt3712_basic_test.yaml) | [SVG](../../waveforms/tt3712_basic_test.svg) | [Project 3712](https://app.tinytapeout.com/projects/3712) |
-| JayF-HA | ⭐ | S | [YAML](../data/tt3713_jayf_ha.yaml) | [SVG](../../waveforms/tt3713_uo_out.svg) | [Project 3713](https://app.tinytapeout.com/projects/3713) |
-| First tinytapeout 234 (Logic & Pass-through) | ⭐ | S | [YAML](../data/tt3714_first_tt.yaml) | [SVG](../../waveforms/tt3714_first_tt.svg) | [Project 3714](https://app.tinytapeout.com/projects/3714) |
-| Switch deBounce for Rotary Encoder | ⭐ | S | [YAML](../data/tt3715_debounce.yaml) | [SVG](../../waveforms/tt3715_debounce.svg) | [Project 3715](https://app.tinytapeout.com/projects/3715) |
-| Tiny Tapeout chip | ⭐ | S | [YAML](../data/tt3716.yaml) | [SVG](../../waveforms/tt3716.svg) | [Project 3716](https://app.tinytapeout.com/projects/3716) |
-| ISC77x8 Side Scrolling Display | ⭐ | S | [YAML](../data/tt3717_isc77x8.yaml) | [SVG](../../waveforms/tt3717_isc77x8.svg) | [Project 3717](https://app.tinytapeout.com/projects/3717) |
-| Hidden combination | ⭐ | S | [YAML](../data/tt3718_hidden_combination.yaml) | [SVG](../../waveforms/tt3718_ui_in.svg) | [Project 3718](https://app.tinytapeout.com/projects/3718) |
-| Test (XOR & D-FlipFlop) | ⭐ | S | [YAML](../data/tt3719_test.yaml) | [SVG](../../waveforms/tt3719_test.svg) | [Project 3719](https://app.tinytapeout.com/projects/3719) |
-| Copenhagen Workshop Project | ⭐ | S | [YAML](../data/tt3720_copenhagen.yaml) | [SVG](../../waveforms/tt3720_copenhagen.svg) | [Project 3720](https://app.tinytapeout.com/projects/3720) |
-| Design_test_workshop | ⭐ | S | [YAML](../data/tt3722_design_test_workshop.yaml) | [SVG](../../waveforms/tt3722_uio_in.svg) | [Project 3722](https://app.tinytapeout.com/projects/3722) |
-| tt3723-7seg-viewer | ⭐ | S | [YAML](../data/tt3723_7seg_viewer.yaml) | [SVG](../../waveforms/tt3723_7seg_viewer.svg) | [Project 3723](https://app.tinytapeout.com/projects/3723) |
-| sree | ⭐ | S | [YAML](../data/tt3724_sree.yaml) | [SVG](../../waveforms/tt3724_sree.svg) | [Project 3724](https://app.tinytapeout.com/projects/3724) |
-| Tiny Tapeout Test Gates | ⭐ | S | [YAML](../data/tt3725_gates.yaml) | [SVG](../../waveforms/tt3725_gates.svg) | [Project 3725](https://app.tinytapeout.com/projects/3725) |
-| Johnson counter | ⭐ | S | [YAML](../data/tt3726_johnson.yaml) | [SVG](../../waveforms/tt3726_johnson.svg) | [Project 3726](https://app.tinytapeout.com/projects/3726) |
-| TestWorkShop | ⭐ | S | [YAML](../data/tt3728_testworkshop.yaml) | [SVG](../../waveforms/tt3728_uo_out.svg) | [Project 3728](https://app.tinytapeout.com/projects/3728) |
-| Tiny Tapeout Test | ⭐ | S | [YAML](../data/tt3730_kristoffer.yaml) | [SVG](../../waveforms/tt3730_kristoffer.svg) | [Project 3730](https://app.tinytapeout.com/projects/3730) |
-| fullAdder | ⭐ | S | [YAML](../data/tt3731.yaml) | [SVG](../../waveforms/tt3731.svg) | [Project 3731](https://app.tinytapeout.com/projects/3731) |
-| Smart LED digital | ⭐ | S | [YAML](../data/tt3733_smart_led.yaml) | [SVG](../../waveforms/tt3733_smart_led.svg) | [Project 3733](https://app.tinytapeout.com/projects/3733) |
-| test project | ⭐ | S | [YAML](../data/tt3734_test_project.yaml) | [SVG](../../waveforms/tt3734_ui_in.svg) | [Project 3734](https://app.tinytapeout.com/projects/3734) |
-| Workshop | ⭐ | S | [YAML](../data/tt3735_workshop.yaml) | [SVG](../../waveforms/tt3735_workshop.svg) | [Project 3735](https://app.tinytapeout.com/projects/3735) |
-| Verilog ring oscillator V2 | ⭐ | S | [YAML](../data/tt3737_ringosc.yaml) | [SVG](../../waveforms/tt3737_ringosc.svg) | [Project 3737](https://app.tinytapeout.com/projects/3737) |
-| ADPLL | ⭐ | S | [YAML](../data/tt3738_adpll.yaml) | [SVG](../../waveforms/tt3738_adpll.svg) | [Project 3738](https://app.tinytapeout.com/projects/3738) |
-| tiny_tester | ⭐ | S | [YAML](../data/tt3740_tiny_tester.yaml) | [SVG](../../waveforms/tt3740_tiny_tester.svg) | [Project 3740](https://app.tinytapeout.com/projects/3740) |
-| Wedgetail TCDE REV01 | ⭐ | S | [YAML](../data/tt3743_wedgetail.yaml) | [SVG](../../waveforms/tt3743_wedgetail.svg) | [Project 3743](https://app.tinytapeout.com/projects/3743) |
-| Lab and Lectures SoC | ⭐ | S | [YAML](../data/tt3745_soc.yaml) | [SVG](../../waveforms/tt3745_soc.svg) | [Project 3745](https://app.tinytapeout.com/projects/3745) |
-| ttihp-HDSISO8 | ⭐ | S | [YAML](../data/tt3747_hdsiso8.yaml) | [SVG](../../waveforms/tt3747_hdsiso8.svg) | [Project 3747](https://app.tinytapeout.com/projects/3747) |
-| FOMO | ⭐ | S | [YAML](../data/tt3753_fomo.yaml) | [SVG](../../waveforms/tt3753_fomo.svg) | [Project 3753](https://app.tinytapeout.com/projects/3753) |
-| Tiny Tapeout Factory Test for ttihp-timer | ⭐ | S | [YAML](../data/tt3755_timer_test.yaml) | [SVG](../../waveforms/tt3755_timer_test.svg) | [Project 3755](https://app.tinytapeout.com/projects/3755) |
-| Photo Frame | ⭐ | S | [YAML](../data/tt3756_photo_frame.yaml) | [SVG](../../waveforms/tt3756_uo_out.svg) | [Project 3756](https://app.tinytapeout.com/projects/3756) |
-| Canright SBOX | ⭐ | S | [YAML](../data/tt3763_canright_sbox.yaml) | [SVG](../../waveforms/tt3763_ui_in.svg) | [Project 3763](https://app.tinytapeout.com/projects/3763) |
-| Silly Mixer | ⭐ | S | [YAML](../data/tt3764_mixer.yaml) | [SVG](../../waveforms/tt3764_mixer.svg) | [Project 3764](https://app.tinytapeout.com/projects/3764) |
-| 8-bit SEM Floating-Point Multiplier | ⭐ | S | [YAML](../data/tt3766.yaml) | [SVG](../../waveforms/tt3766.svg) | [Project 3766](https://app.tinytapeout.com/projects/3766) |
-| Count To Ten | ⭐ | S | [YAML](../data/tt3771_count_to_ten.yaml) | [SVG](../../waveforms/tt3771_count_to_ten.svg) | [Project 3771](https://app.tinytapeout.com/projects/3771) |
-| Chip ROM | ⭐ | S | [YAML](../data/tt3782_chip_rom.yaml) | [SVG](../../waveforms/tt3782_chip_rom.svg) | [Project 3782](https://app.tinytapeout.com/projects/3782) |
-| 1-bit counter and 2-to-4 decoder | ⭐ | S | [YAML](../data/tt3802_counter_decoder.yaml) | [SVG](../../waveforms/tt3802_counter_decoder.svg) | [Project 3802](https://app.tinytapeout.com/projects/3802) |
-| Hardware UTF Encoder/Decoder | ⭐ | S | [YAML](../data/tt3812_utf8.yaml) | [SVG](../../waveforms/tt3812_utf8.svg) | [Project 3812](https://app.tinytapeout.com/projects/3812) |
-| 8-bit Prime Number Detector | ⭐ | S | [YAML](../data/tt3949_prime_detector.yaml) | [SVG](../../waveforms/tt3949_prime_detector.svg) | [Project 3949](https://app.tinytapeout.com/projects/3949) |
-| VoGAl | ⭐ | S | [YAML](../data/tt3957_vogal.yaml) | [SVG](../../waveforms/tt3957_vogal.svg) | [Project 3957](https://app.tinytapeout.com/projects/3957) |
-| smolCPU | ⭐ | S | [YAML](../data/tt3970_smolcpu.yaml) | [SVG](../../waveforms/tt3970_smolcpu.svg) | [Project 3970](https://app.tinytapeout.com/projects/3970) |
-| O2ELHd 7segment display | ⭐ | S | [YAML](../data/tt3974_7seg_display.yaml) | [SVG](../../waveforms/tt3974_7seg_display.svg) | [Project 3974](https://app.tinytapeout.com/projects/3974) |
-| vga_ca | ⭐ | S | [YAML](../data/tt3975_vgaca.yaml) | [SVG](../../waveforms/tt3975_vgaca.svg) | [Project 3975](https://app.tinytapeout.com/projects/3975) |
-| Tschai's Tic-Tac-Toe | ⭐ | S | [YAML](../data/tt3979_tictactoe.yaml) | [SVG](../../waveforms/tt3979_tictactoe.svg) | [Project 3979](https://app.tinytapeout.com/projects/3979) |
-| microlane demo project | ⭐ | S | [YAML](../data/tt3988_microlane_demo.yaml) | [SVG](../../waveforms/tt3988_uo_out.svg) | [Project 3988](https://app.tinytapeout.com/projects/3988) |
-| tiny_dino | ⭐ | S | [YAML](../data/tt3998_tiny_dino.yaml) | [SVG](../../waveforms/tt3998_tiny_dino.svg) | [Project 3998](https://app.tinytapeout.com/projects/3998) |
-| Infinity Core | ⭐ | S | [YAML](../data/tt4002_infinity_core.yaml) | [SVG](../../waveforms/tt4002_uo_out.svg) | [Project 4002](https://app.tinytapeout.com/projects/4002) |
-| 4-bit processor | ⭐ | S | [YAML](../data/tt4003_4bit_processor.yaml) | [SVG](../../waveforms/tt4003_ui_in.svg) | [Project 4003](https://app.tinytapeout.com/projects/4003) |
+| [7 Segment BCD / CLA](tt3684.md) | ⭐ | S | [YAML](../data/tt3684_cla_bcd.yaml) | [SVG](../../waveforms/tt3684_cla_bcd.svg) | [Project 3684](https://app.tinytapeout.com/projects/3684) |
+| [Paafus First Chip](tt3685.md) | ⭐ | S | [YAML](../data/tt3685_paafu.yaml) | [SVG](../../waveforms/tt3685_paafu.svg) | [Project 3685](https://app.tinytapeout.com/projects/3685) |
+| [MyFirstChip (Patterns)](tt3686.md) | ⭐ | S | [YAML](../data/tt3686_chip.yaml) | [SVG](../../waveforms/tt3686_uo_out.svg) | [Project 3686](https://app.tinytapeout.com/projects/3686) |
+| [Half Adder](tt3687.md) | ⭐ | S | [YAML](../data/tt3687_half_adder.yaml) | [SVG](../../waveforms/tt3687_half_adder.svg) | [Project 3687](https://app.tinytapeout.com/projects/3687) |
+| [idk](tt3688.md) | ⭐ | S | [YAML](../data/tt3688_idk.yaml) | [SVG](../../waveforms/tt3688_ui_in.svg) | [Project 3688](https://app.tinytapeout.com/projects/3688) |
+| [Simple Counter (Ripple Counter)](tt3689.md) | ⭐ | S | [YAML](../data/tt3689_simple_counter.yaml) | [SVG](../../waveforms/tt3689_simple_counter.svg) | [Project 3689](https://app.tinytapeout.com/projects/3689) |
+| [Hello World (Logic gates)](tt3691.md) | ⭐ | S | [YAML](../data/tt3691_hello.yaml) | [SVG](../../waveforms/tt3691_hello.svg) | [Project 3691](https://app.tinytapeout.com/projects/3691) |
+| [SPI RAM Driver](tt3692.md) | ⭐ | S | [YAML](../data/tt3692_spi_ram.yaml) | [SVG](../../waveforms/tt3692_spi_ram.svg) | [Project 3692](https://app.tinytapeout.com/projects/3692) |
+| [TinyTapeNkTest](tt3693.md) | ⭐ | S | [YAML](../data/tt3693_tiny_tape_nk_test.yaml) | [SVG](../../waveforms/tt3693_uo_out.svg) | [Project 3693](https://app.tinytapeout.com/projects/3693) |
+| [WIP Bin to Dec (OR Logic)](tt3694.md) | ⭐ | S | [YAML](../data/tt3694_bin2dec_wip.yaml) | [SVG](../../waveforms/tt3694_bin2dec_wip.svg) | [Project 3694](https://app.tinytapeout.com/projects/3694) |
+| [Malthes First Template](tt3695.md) | ⭐ | S | [YAML](../data/tt3695_malthe.yaml) | [SVG](../../waveforms/tt3695_malthe.svg) | [Project 3695](https://app.tinytapeout.com/projects/3695) |
+| [Alex first circuit (Johnson counter)](tt3696.md) | ⭐ | S | [YAML](../data/tt3696_circuit.yaml) | [SVG](../../waveforms/tt3696_circuit.svg) | [Project 3696](https://app.tinytapeout.com/projects/3696) |
+| [GDS Test (Inverter + Pass-through)](tt3697.md) | ⭐ | S | [YAML](../data/tt3697_gds_test.yaml) | [SVG](../../waveforms/tt3697_gds_test.svg) | [Project 3697](https://app.tinytapeout.com/projects/3697) |
+| [4-bit full adder](tt3698.md) | ⭐ | S | [YAML](../data/tt3698_4_bit_full_adder.yaml) | [SVG](../../waveforms/tt3698_ui_in.svg) | [Project 3698](https://app.tinytapeout.com/projects/3698) |
+| [Tiny Tapeout First Design (Logic Gates)](tt3699.md) | ⭐ | S | [YAML](../data/tt3699_first_design.yaml) | [SVG](../../waveforms/tt3699_first_design.svg) | [Project 3699](https://app.tinytapeout.com/projects/3699) |
+| [One One](tt3700.md) | ⭐ | S | [YAML](../data/tt3700_one_one.yaml) | [SVG](../../waveforms/tt3700_one_one.svg) | [Project 3700](https://app.tinytapeout.com/projects/3700) |
+| [Cremedelcreme](tt3701.md) | ⭐ | S | [YAML](../data/tt3701.yaml) | [SVG](../../waveforms/tt3701.svg) | [Project 3701](https://app.tinytapeout.com/projects/3701) |
+| [Test Gates](tt3702.md) | ⭐ | S | [YAML](../data/tt3702_test_gates.yaml) | [SVG](../../waveforms/tt3702_test_gates.svg) | [Project 3702](https://app.tinytapeout.com/projects/3702) |
+| [And_Or](tt3703.md) | ⭐ | S | [YAML](../data/tt3703_and_or.yaml) | [SVG](../../waveforms/tt3703_and_or.svg) | [Project 3703](https://app.tinytapeout.com/projects/3703) |
+| [Hello GDS](tt3704.md) | ⭐ | S | [YAML](../data/tt3704_hello.yaml) | [SVG](../../waveforms/tt3704_hello.svg) | [Project 3704](https://app.tinytapeout.com/projects/3704) |
+| [demo_chip](tt3705.md) | ⭐ | S | [YAML](../data/tt3705_demo_chip.yaml) | [SVG](../../waveforms/tt3705_demo_chip.svg) | [Project 3705](https://app.tinytapeout.com/projects/3705) |
+| [Scott's first Wokwi design](tt3706.md) | ⭐ | S | [YAML](../data/tt3706.yaml) | [SVG](../../waveforms/tt3706.svg) | [Project 3706](https://app.tinytapeout.com/projects/3706) |
+| [tinytapeout_henningp_2bin_to_4bit_decoder](tt3707.md) | ⭐ | S | [YAML](../data/tt3707_decoder.yaml) | [SVG](../../waveforms/tt3707_decoder.svg) | [Project 3707](https://app.tinytapeout.com/projects/3707) |
+| [My first design](tt3708.md) | ⭐ | S | [YAML](../data/tt3708_my_first_design.yaml) | [SVG](../../waveforms/tt3708_my_first_design.svg) | [Project 3708](https://app.tinytapeout.com/projects/3708) |
+| [TTIHP26a_Luke_Meta](tt3709.md) | ⭐ | S | [YAML](../data/tt3709_luke_meta.yaml) | [SVG](../../waveforms/tt3709_luke_meta.svg) | [Project 3709](https://app.tinytapeout.com/projects/3709) |
+| [Undecided](tt3710.md) | ⭐ | S | [YAML](../data/tt3710_undecided.yaml) | [SVG](../../waveforms/tt3710_undecided.svg) | [Project 3710](https://app.tinytapeout.com/projects/3710) |
+| [Tiny Tapeout Workshop Test (NAND)](tt3711.md) | ⭐ | S | [YAML](../data/tt3711_gates.yaml) | [SVG](../../waveforms/tt3711_uo_out.svg) | [Project 3711](https://app.tinytapeout.com/projects/3711) |
+| [Amaury Basic Test](tt3712.md) | ⭐ | S | [YAML](../data/tt3712_basic_test.yaml) | [SVG](../../waveforms/tt3712_basic_test.svg) | [Project 3712](https://app.tinytapeout.com/projects/3712) |
+| [JayF-HA](tt3713.md) | ⭐ | S | [YAML](../data/tt3713_jayf_ha.yaml) | [SVG](../../waveforms/tt3713_uo_out.svg) | [Project 3713](https://app.tinytapeout.com/projects/3713) |
+| [First tinytapeout 234 (Logic & Pass-through)](tt3714.md) | ⭐ | S | [YAML](../data/tt3714_first_tt.yaml) | [SVG](../../waveforms/tt3714_first_tt.svg) | [Project 3714](https://app.tinytapeout.com/projects/3714) |
+| [Switch deBounce for Rotary Encoder](tt3715.md) | ⭐ | S | [YAML](../data/tt3715_debounce.yaml) | [SVG](../../waveforms/tt3715_debounce.svg) | [Project 3715](https://app.tinytapeout.com/projects/3715) |
+| [Tiny Tapeout chip](tt3716.md) | ⭐ | S | [YAML](../data/tt3716.yaml) | [SVG](../../waveforms/tt3716.svg) | [Project 3716](https://app.tinytapeout.com/projects/3716) |
+| [ISC77x8 Side Scrolling Display](tt3717.md) | ⭐ | S | [YAML](../data/tt3717_isc77x8.yaml) | [SVG](../../waveforms/tt3717_isc77x8.svg) | [Project 3717](https://app.tinytapeout.com/projects/3717) |
+| [Hidden combination](tt3718.md) | ⭐ | S | [YAML](../data/tt3718_hidden_combination.yaml) | [SVG](../../waveforms/tt3718_ui_in.svg) | [Project 3718](https://app.tinytapeout.com/projects/3718) |
+| [Test (XOR & D-FlipFlop)](tt3719.md) | ⭐ | S | [YAML](../data/tt3719_test.yaml) | [SVG](../../waveforms/tt3719_test.svg) | [Project 3719](https://app.tinytapeout.com/projects/3719) |
+| [Copenhagen Workshop Project](tt3720.md) | ⭐ | S | [YAML](../data/tt3720_copenhagen.yaml) | [SVG](../../waveforms/tt3720_copenhagen.svg) | [Project 3720](https://app.tinytapeout.com/projects/3720) |
+| [Design_test_workshop](tt3722.md) | ⭐ | S | [YAML](../data/tt3722_design_test_workshop.yaml) | [SVG](../../waveforms/tt3722_uio_in.svg) | [Project 3722](https://app.tinytapeout.com/projects/3722) |
+| [tt3723-7seg-viewer](tt3723.md) | ⭐ | S | [YAML](../data/tt3723_7seg_viewer.yaml) | [SVG](../../waveforms/tt3723_7seg_viewer.svg) | [Project 3723](https://app.tinytapeout.com/projects/3723) |
+| [sree](tt3724.md) | ⭐ | S | [YAML](../data/tt3724_sree.yaml) | [SVG](../../waveforms/tt3724_sree.svg) | [Project 3724](https://app.tinytapeout.com/projects/3724) |
+| [Tiny Tapeout Test Gates](tt3725.md) | ⭐ | S | [YAML](../data/tt3725_gates.yaml) | [SVG](../../waveforms/tt3725_gates.svg) | [Project 3725](https://app.tinytapeout.com/projects/3725) |
+| [Johnson counter](tt3726.md) | ⭐ | S | [YAML](../data/tt3726_johnson.yaml) | [SVG](../../waveforms/tt3726_johnson.svg) | [Project 3726](https://app.tinytapeout.com/projects/3726) |
+| [TestWorkShop](tt3728.md) | ⭐ | S | [YAML](../data/tt3728_testworkshop.yaml) | [SVG](../../waveforms/tt3728_uo_out.svg) | [Project 3728](https://app.tinytapeout.com/projects/3728) |
+| [Tiny Tapeout Test](tt3730.md) | ⭐ | S | [YAML](../data/tt3730_kristoffer.yaml) | [SVG](../../waveforms/tt3730_kristoffer.svg) | [Project 3730](https://app.tinytapeout.com/projects/3730) |
+| [fullAdder](tt3731.md) | ⭐ | S | [YAML](../data/tt3731.yaml) | [SVG](../../waveforms/tt3731.svg) | [Project 3731](https://app.tinytapeout.com/projects/3731) |
+| [Smart LED digital](tt3733.md) | ⭐ | S | [YAML](../data/tt3733_smart_led.yaml) | [SVG](../../waveforms/tt3733_smart_led.svg) | [Project 3733](https://app.tinytapeout.com/projects/3733) |
+| [test project](tt3734.md) | ⭐ | S | [YAML](../data/tt3734_test_project.yaml) | [SVG](../../waveforms/tt3734_ui_in.svg) | [Project 3734](https://app.tinytapeout.com/projects/3734) |
+| [Workshop](tt3735.md) | ⭐ | S | [YAML](../data/tt3735_workshop.yaml) | [SVG](../../waveforms/tt3735_workshop.svg) | [Project 3735](https://app.tinytapeout.com/projects/3735) |
+| [Verilog ring oscillator V2](tt3737.md) | ⭐ | S | [YAML](../data/tt3737_ringosc.yaml) | [SVG](../../waveforms/tt3737_ringosc.svg) | [Project 3737](https://app.tinytapeout.com/projects/3737) |
+| [ADPLL](tt3738.md) | ⭐ | S | [YAML](../data/tt3738_adpll.yaml) | [SVG](../../waveforms/tt3738_adpll.svg) | [Project 3738](https://app.tinytapeout.com/projects/3738) |
+| [tiny_tester](tt3740.md) | ⭐ | S | [YAML](../data/tt3740_tiny_tester.yaml) | [SVG](../../waveforms/tt3740_tiny_tester.svg) | [Project 3740](https://app.tinytapeout.com/projects/3740) |
+| [Wedgetail TCDE REV01](tt3743.md) | ⭐ | S | [YAML](../data/tt3743_wedgetail.yaml) | [SVG](../../waveforms/tt3743_wedgetail.svg) | [Project 3743](https://app.tinytapeout.com/projects/3743) |
+| [Lab and Lectures SoC](tt3745.md) | ⭐ | S | [YAML](../data/tt3745_soc.yaml) | [SVG](../../waveforms/tt3745_soc.svg) | [Project 3745](https://app.tinytapeout.com/projects/3745) |
+| [ttihp-HDSISO8](tt3747.md) | ⭐ | S | [YAML](../data/tt3747_hdsiso8.yaml) | [SVG](../../waveforms/tt3747_hdsiso8.svg) | [Project 3747](https://app.tinytapeout.com/projects/3747) |
+| [FOMO](tt3753.md) | ⭐ | S | [YAML](../data/tt3753_fomo.yaml) | [SVG](../../waveforms/tt3753_fomo.svg) | [Project 3753](https://app.tinytapeout.com/projects/3753) |
+| [Tiny Tapeout Factory Test for ttihp-timer](tt3755.md) | ⭐ | S | [YAML](../data/tt3755_timer_test.yaml) | [SVG](../../waveforms/tt3755_timer_test.svg) | [Project 3755](https://app.tinytapeout.com/projects/3755) |
+| [Photo Frame](tt3756.md) | ⭐ | S | [YAML](../data/tt3756_photo_frame.yaml) | [SVG](../../waveforms/tt3756_uo_out.svg) | [Project 3756](https://app.tinytapeout.com/projects/3756) |
+| [Canright SBOX](tt3763.md) | ⭐ | S | [YAML](../data/tt3763_canright_sbox.yaml) | [SVG](../../waveforms/tt3763_ui_in.svg) | [Project 3763](https://app.tinytapeout.com/projects/3763) |
+| [Silly Mixer](tt3764.md) | ⭐ | S | [YAML](../data/tt3764_mixer.yaml) | [SVG](../../waveforms/tt3764_mixer.svg) | [Project 3764](https://app.tinytapeout.com/projects/3764) |
+| [8-bit SEM Floating-Point Multiplier](tt3766.md) | ⭐ | S | [YAML](../data/tt3766.yaml) | [SVG](../../waveforms/tt3766.svg) | [Project 3766](https://app.tinytapeout.com/projects/3766) |
+| [Count To Ten](tt3771.md) | ⭐ | S | [YAML](../data/tt3771_count_to_ten.yaml) | [SVG](../../waveforms/tt3771_count_to_ten.svg) | [Project 3771](https://app.tinytapeout.com/projects/3771) |
+| [Chip ROM](tt3782.md) | ⭐ | S | [YAML](../data/tt3782_chip_rom.yaml) | [SVG](../../waveforms/tt3782_chip_rom.svg) | [Project 3782](https://app.tinytapeout.com/projects/3782) |
+| [1-bit counter and 2-to-4 decoder](tt3802.md) | ⭐ | S | [YAML](../data/tt3802_counter_decoder.yaml) | [SVG](../../waveforms/tt3802_counter_decoder.svg) | [Project 3802](https://app.tinytapeout.com/projects/3802) |
+| [Hardware UTF Encoder/Decoder](tt3812.md) | ⭐ | S | [YAML](../data/tt3812_utf8.yaml) | [SVG](../../waveforms/tt3812_utf8.svg) | [Project 3812](https://app.tinytapeout.com/projects/3812) |
+| [8-bit Prime Number Detector](tt3949.md) | ⭐ | S | [YAML](../data/tt3949_prime_detector.yaml) | [SVG](../../waveforms/tt3949_prime_detector.svg) | [Project 3949](https://app.tinytapeout.com/projects/3949) |
+| [VoGAl](tt3957.md) | ⭐ | S | [YAML](../data/tt3957_vogal.yaml) | [SVG](../../waveforms/tt3957_vogal.svg) | [Project 3957](https://app.tinytapeout.com/projects/3957) |
+| [smolCPU](tt3970.md) | ⭐ | S | [YAML](../data/tt3970_smolcpu.yaml) | [SVG](../../waveforms/tt3970_smolcpu.svg) | [Project 3970](https://app.tinytapeout.com/projects/3970) |
+| [O2ELHd 7segment display](tt3974.md) | ⭐ | S | [YAML](../data/tt3974_7seg_display.yaml) | [SVG](../../waveforms/tt3974_7seg_display.svg) | [Project 3974](https://app.tinytapeout.com/projects/3974) |
+| [vga_ca](tt3975.md) | ⭐ | S | [YAML](../data/tt3975_vgaca.yaml) | [SVG](../../waveforms/tt3975_vgaca.svg) | [Project 3975](https://app.tinytapeout.com/projects/3975) |
+| [Tschai's Tic-Tac-Toe](tt3979.md) | ⭐ | S | [YAML](../data/tt3979_tictactoe.yaml) | [SVG](../../waveforms/tt3979_tictactoe.svg) | [Project 3979](https://app.tinytapeout.com/projects/3979) |
+| [microlane demo project](tt3988.md) | ⭐ | S | [YAML](../data/tt3988_microlane_demo.yaml) | [SVG](../../waveforms/tt3988_uo_out.svg) | [Project 3988](https://app.tinytapeout.com/projects/3988) |
+| [tiny_dino](tt3998.md) | ⭐ | S | [YAML](../data/tt3998_tiny_dino.yaml) | [SVG](../../waveforms/tt3998_tiny_dino.svg) | [Project 3998](https://app.tinytapeout.com/projects/3998) |
+| [Infinity Core](tt4002.md) | ⭐ | S | [YAML](../data/tt4002_infinity_core.yaml) | [SVG](../../waveforms/tt4002_uo_out.svg) | [Project 4002](https://app.tinytapeout.com/projects/4002) |
+| [4-bit processor](tt4003.md) | ⭐ | S | [YAML](../data/tt4003_4bit_processor.yaml) | [SVG](../../waveforms/tt4003_ui_in.svg) | [Project 4003](https://app.tinytapeout.com/projects/4003) |
 | Triple Modular Redundancy | ⭐ | S | N/A | N/A | [Project 4005](https://app.tinytapeout.com/projects/4005) |
 | VGA multiplex with TRNG | ⭐ | S | N/A | N/A | [Project 4010](https://app.tinytapeout.com/projects/4010) |
 | UART-ALU Processor | ⭐ | S | N/A | N/A | [Project 4014](https://app.tinytapeout.com/projects/4014) |


### PR DESCRIPTION
This change ensures that users can easily navigate from the project overview table in TTIHP26A_PROJECTS.md to the detailed documentation for each project. It also codifies this requirement as a rule in GEMINI.md to ensure future maintainability. I have updated the overview table by running the generator script and verified that the links are correctly pointing to existing documentation files.

Fixes #144

---
*PR created automatically by Jules for task [11900838015072588630](https://jules.google.com/task/11900838015072588630) started by @chatelao*