### PR TITLE
Setup ReadTheDocs documentation infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 waveforms/*.png
 src/puml/*.puml
 test/*.yaml
+site/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+python:
+  install:
+    - requirements: requirements.txt
+
+mkdocs:
+  configuration: mkdocs.yml

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -20,7 +20,7 @@
 - ROADMAP.md - Planned & finished tasks of the product
 - README.md - Overview of the product
 - HOWTO.md - Usage instruction of the product
-- / - Keep only GEMINI.md, HOWTO.md, README.md, DECISION.md, DISCARDED.md, ROADMAP.md, requirements.txt and .gitignore in the root directory
+- / - Keep only GEMINI.md, HOWTO.md, README.md, DECISION.md, DISCARDED.md, ROADMAP.md, requirements.txt, .gitignore, .readthedocs.yaml and mkdocs.yml in the root directory
 - /specifications - Download and store original specification, add ".original." in the name before the extension
 - /specifications - NEVER change ".original." files
 - /specifications - Convert "non .md" files for caching and readability purpose to Markdown

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,12 @@
+site_name: TT Test Framework
+docs_dir: src/docs
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - search.suggest
+    - search.highlight
+
+nav:
+  - Welcome: index.md
+  - Projects Overview: TTIHP26A_PROJECTS.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ pytest
 wavedrom
 ruamel.yaml
 svgwrite
+mkdocs
+mkdocs-material

--- a/src/docs/index.md
+++ b/src/docs/index.md
@@ -1,0 +1,16 @@
+# TT Test Framework Documentation
+
+Welcome to the documentation for the TT Test Framework. This framework is designed to define and verify test steps for TinyTapeout projects using a structured YAML format.
+
+## Quick Links
+
+- [Projects Overview](TTIHP26A_PROJECTS.md): A comprehensive list of projects from the TTIHP26A shuttle, including their novelty ratings, sizes, and links to test data and waveforms.
+
+## About the Framework
+
+The framework allows for:
+- Structured test sequence definitions in YAML.
+- Automated generation of WaveDrom timing diagrams.
+- Functional verification of TinyTapeout designs.
+
+Refer to the [README.md](https://github.com/tinytapeout/tt-test-framework/blob/main/README.md) for installation and usage instructions.


### PR DESCRIPTION
This change sets up the project for documentation hosting on ReadTheDocs. It uses MkDocs with the Material theme, pointing to the existing project documentation in `src/docs/`. A new landing page `index.md` is provided, and the project's root directory policy in `GEMINI.md` has been updated to accommodate the necessary configuration files.

Fixes #146

---
*PR created automatically by Jules for task [8798778997147825516](https://jules.google.com/task/8798778997147825516) started by @chatelao*