### PR TITLE
Add link to Read the Docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This tool allows you to define the operational sequence of your Tiny-Tapeout pro
 - **Waveform Generation**: Automatically creates WaveDrom timing diagrams.
 - **MicroPython Compatible**: Designed to reflect steps used in hardware testing with the TT DevKit.
 
+## Documentation
+
+The full documentation is available at [tt-test-framework.readthedocs.io](https://tt-test-framework.readthedocs.io/).
+
 ## Project Structure
 
 - `src/schema`: Defines the YAML structure.


### PR DESCRIPTION
Added a "Documentation" section to `README.md` with a link to `https://tt-test-framework.readthedocs.io/`. Verified the change and ran existing tests.

Fixes #151

---
*PR created automatically by Jules for task [15874690591428880934](https://jules.google.com/task/15874690591428880934) started by @chatelao*