### PR TITLE
Add functional test documentation links to YAML metadata

### DIFF
--- a/src/data/micropython_example.yaml
+++ b/src/data/micropython_example.yaml
@@ -82,3 +82,7 @@ test_steps:
     cycles: 1
     values:
       UO_OUT: "Result[7:0]"
+
+metadata:
+  source: "https://github.com/chatelao/ttihp-fp8-mul"
+  doc: "https://github.com/chatelao/ttihp-fp8-mul/blob/ihp-sg13cmos5l/docs/test.md#functional-test-sequences"

--- a/src/data/tt3990_fp8_mul.yaml
+++ b/src/data/tt3990_fp8_mul.yaml
@@ -1,6 +1,7 @@
 project: "OCP MXFP8 Streaming MAC Unit"
 metadata:
   source: "https://github.com/chatelao/ttihp-fp8-mul"
+  doc: "https://github.com/chatelao/ttihp-fp8-mul/blob/ihp-sg13cmos5l/docs/test.md#functional-test-sequences"
 signals:
   ui_in:
     type: "input"

--- a/src/schema/test_steps.yaml
+++ b/src/schema/test_steps.yaml
@@ -9,6 +9,8 @@ properties:
     properties:
       source:
         type: string
+      doc:
+        type: string
       async:
         type: boolean
   signals:
@@ -36,6 +38,8 @@ properties:
           type: object
           properties:
             source:
+              type: string
+            doc:
               type: string
         test_steps:
           $ref: "#/definitions/test_steps"


### PR DESCRIPTION
This change introduces a new `doc` field in the test data YAML metadata schema, allowing projects to link to their equivalent functional test documentation. Specifically, it adds links for the OCP MXFP8 MAC project (tt3990) to its detailed test sequences in the source repository.

Fixes #175

---
*PR created automatically by Jules for task [15898677686466081184](https://jules.google.com/task/15898677686466081184) started by @chatelao*